### PR TITLE
CubeCamera: Fix wrong envMap texture with grouped Meshes

### DIFF
--- a/src/components/CubeCamera.svelte
+++ b/src/components/CubeCamera.svelte
@@ -1,7 +1,12 @@
 <script lang="typescript">
     import { onMount } from "svelte"
     import { get_current_component } from "svelte/internal"
-    import { WebGLCubeRenderTarget, CubeCamera, Mesh } from "svelthree-three"
+    import {
+        WebGLCubeRenderTarget,
+        CubeCamera,
+        Mesh,
+        Vector3
+    } from "svelthree-three"
     //import { UniversalPropIterator } from "../utils/UniversalPropIterator.svelte"
     import { svelthreeStores } from "../stores.js"
 
@@ -111,7 +116,9 @@
     export function doUpdate() {
         if ($svelthreeStores[sti].currentSceneIndex) {
             parent.visible = false
-            cubeCamera.position.copy(parent.position)
+            let wp: Vector3 = new Vector3()
+            parent.getWorldPosition(wp)
+            cubeCamera.position.copy(wp)
             let renderer = $svelthreeStores[sti].renderer
             let scene =
                 $svelthreeStores[sti].scenes[


### PR DESCRIPTION
Fixes issue with wrong envMap texture when grouping Meshes.
Fairly simple by setting the position of cubeCamera (native CubeCamera) to **world position** (see [getWorldPosition](https://threejs.org/docs/#api/en/core/Object3D.getWorldPosition)) of the parent Mesh (native Mesh created by the parent Mesh component).