### PR TITLE
refactor: changed `<script lang="typescript">` to `<script lang="ts">`.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ export default {
     output: [
         /* 
 		The attempt to generate *.d.ts from *.svelte component's ts-code failed.
-		Rollup generates *.d.ts of *.ts files only, not of ts-code inside <script lang="typescript">!
+		Rollup generates *.d.ts of *.ts files only, not of ts-code inside <script lang="ts">!
 		Doing <script lang="typescript" src="Foo.ts">:
 		- component Foo.svelte gets bundled correctly (works)
 		- Foo.d.ts gets exported but is not wrapped into a 'SvelteComponent' class or similar (is completely detached),

--- a/src/components/AmbientLight.svelte
+++ b/src/components/AmbientLight.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/Camera.svelte
+++ b/src/components/Camera.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/Canvas.svelte
+++ b/src/components/Canvas.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/CubeCamera.svelte
+++ b/src/components/CubeCamera.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     import { onMount } from "svelte"
     import { get_current_component } from "svelte/internal"
     import {

--- a/src/components/DirectionalLight.svelte
+++ b/src/components/DirectionalLight.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/Empty.svelte
+++ b/src/components/Empty.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/HemisphereLight.svelte
+++ b/src/components/HemisphereLight.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/Light.svelte
+++ b/src/components/Light.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/LoadedGLTF.svelte
+++ b/src/components/LoadedGLTF.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/Mesh.svelte
+++ b/src/components/Mesh.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/OrbitControls.svelte
+++ b/src/components/OrbitControls.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/OrthographicCamera.svelte
+++ b/src/components/OrthographicCamera.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/PerspectiveCamera.svelte
+++ b/src/components/PerspectiveCamera.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/PointLight.svelte
+++ b/src/components/PointLight.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/RectAreaLight.svelte
+++ b/src/components/RectAreaLight.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/Scene.svelte
+++ b/src/components/Scene.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/SessionAR.svelte
+++ b/src/components/SessionAR.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/SessionVR.svelte
+++ b/src/components/SessionVR.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/SpotLight.svelte
+++ b/src/components/SpotLight.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/SvelthreeAnimation.svelte
+++ b/src/components/SvelthreeAnimation.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     import { onMount } from "svelte"
     import { SvelthreeAnimationManager } from "../utils/Sv3AnimationManager.svelte"
     import { Object3D, Scene } from "svelthree-three"

--- a/src/components/SvelthreeInteraction.svelte
+++ b/src/components/SvelthreeInteraction.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/SvelthreeInteractionAR.svelte
+++ b/src/components/SvelthreeInteractionAR.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/SvelthreeInteractionVR.svelte
+++ b/src/components/SvelthreeInteractionVR.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/WebGLRenderer.svelte
+++ b/src/components/WebGLRenderer.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */

--- a/src/components/WebXR.svelte
+++ b/src/components/WebXR.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
     /**
      * @author Vatroslav Vrbanic @see https://github.com/vatro
      */


### PR DESCRIPTION
Hi @vatro,

First of all, thanks for making this! 
I saw the examples on the documentation website and of course wanted to try it out in my own app.

After importing some of the components classes I noticed the following deprecation warning in my terminal:
`[svelte-preprocess] Deprecation notice: using 'lang="typescript"' is no longer recommended and will be removed in the next major version. Please use 'lang="ts"' instead.`

Since it's a small quick change I thought to help you a bit and created this PR for you.

Hope it saves you some time :)!

Happy coding!

Ron