### PR TITLE
Switch to `default-svelte-first` approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,13 @@ node_modules
 /src/lib/components-check
 /src/lib/components-internal-check
 generate_svelthree_components.js
+generate_state_in_ungenerated_components.js
 
 # any routes
 src/routes/
 
 # app.html
 src/app.html
+
+# temporary `acc` folder while building (is removed after build)
+src/lib/acc

--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
 	"license": "MIT",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "svelte-kit sync && svelte-package && node ./postprocess_package.js",
+		"build": "svelte-kit sync && svelte-package",
+		"publish:__my_npm": "cd ./package && npm pack --pack-destination ../../__my_npm/ .",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
 		"lint : quiet": "prettier --check . && eslint --quiet .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"prebuild": "npm run format && npm run check && npm run lint && node ./prebuild.js",
+		"postbuild": "node ./postprocess_package.js && rimraf src/lib/acc",
+		"reinstall": "rimraf .svelte-kit && rimraf .vercel && rimraf build && rimraf node_modules/.vite && rimraf node_modules && rimraf package-lock.json && npm i"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "next",

--- a/package.json
+++ b/package.json
@@ -21,29 +21,29 @@
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
 		"@sveltejs/package": "next",
-		"@typescript-eslint/eslint-plugin": "^5.27.0",
-		"@typescript-eslint/parser": "^5.27.0",
-		"eslint": "^8.16.0",
-		"eslint-config-prettier": "^8.3.0",
+		"@typescript-eslint/eslint-plugin": "^5.46.1",
+		"@typescript-eslint/parser": "^5.46.1",
+		"eslint": "^8.30.0",
+		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"fs-extra": "^10.1.0",
-		"prettier": "^2.6.2",
-		"prettier-plugin-svelte": "^2.7.0",
-		"svelte": "^3.44.0",
-		"svelte-check": "^2.7.1",
-		"svelte-preprocess": "^4.10.6",
-		"three": "0.141.x",
-		"tslib": "^2.3.1",
-		"typescript": "^4.7.4",
-		"vite": "^3.1.0-beta.1"
+		"fs-extra": "^11.1.0",
+		"prettier": "^2.8.1",
+		"prettier-plugin-svelte": "^2.9.0",
+		"svelte": "^3.54.0",
+		"svelte-check": "^2.10.2",
+		"svelte-preprocess": "^5.0.0",
+		"three": "0.147.x",
+		"@types/three": "0.125.x - 0.147.x",
+		"tslib": "^2.4.1",
+		"typescript": "^4.9.4",
+		"vite": "^4.0.2"
 	},
 	"peerDependencies": {
-		"svelte": "3.44.2 - 3.49.0",
-		"svelte-accmod-patch": "^1.0.2",
-		"three": "0.125.x - 0.141.x"
+		"svelte": "^3.54.0",
+		"three": "0.125.x - 0.147.x"
 	},
 	"optionalDependencies": {
-		"@types/three": "0.141.x"
+		"@types/three": "0.125.x - 0.147.x"
 	},
 	"type": "module",
 	"repository": {

--- a/postprocess_package.js
+++ b/postprocess_package.js
@@ -1,265 +1,293 @@
-import * as fs from "node:fs/promises"
+import * as fsp from "node:fs/promises"
 import * as path from "path"
 
-const project_root_abs = process.cwd()
-const fns = []
+export const postprocess_package = async (target_folder, using_accessors) => {
+	const project_root_abs = process.cwd()
+	const fns = []
 
-const using_accessors = false
+	// --- CODE REPLACEMENT TASKS ---
 
-// --- CODE REPLACEMENT TASKS ---
+	const replace_tasks = [
+		{
+			file_path: path.join(project_root_abs, `/${target_folder}/components/Mesh.svelte.d.ts`),
+			todo: [
+				{
+					//regex: /get mat\(\).*}>>;/s,
+					//regex: /get mat\(\).*?};/s,
+					regex: /get mat\(\).*?>;/s, //opt2
+					//replacement: `get mat(): MeshProps<AssignedMaterial>['mat'];`
+					replacement: `get mat(): PropMat<AssignedMaterial>;`
+				},
+				{
+					//regex: /set mat\(.*}>>\);/s,
+					regex: /set mat\(.*?\);/s, // opt2
+					//replacement: `set mat(_: MeshProps<AssignedMaterial>['mat']);`
+					replacement: `set mat(_: PropMat<AssignedMaterial> | undefined);`
+				},
+				{
+					regex: /Mesh<MeshAssignableMaterial>/g,
+					replacement: `Mesh<AssignedMaterial>`
+				}
+			]
+		},
+		{
+			file_path: path.join(project_root_abs, `/${target_folder}/components/Points.svelte.d.ts`),
+			todo: [
+				{
+					//regex: /get mat\(\).*}>>;/s,
+					//regex: /get mat\(\).*?};/s,
+					regex: /get mat\(\).*?>;/s, //opt2
+					//replacement: `get mat(): PointsProps<AssignedMaterial>['mat'];`
+					replacement: `get mat(): PropMat<AssignedMaterial>;`
+				},
+				{
+					//regex: /set mat\(.*}>>\);/s,
+					regex: /set mat\(.*?\);/s, // opt2
+					//replacement: `set mat(_: PointsProps<AssignedMaterial>['mat']);`
+					replacement: `set mat(_: PropMat<AssignedMaterial> | undefined);`
+				},
+				{
+					regex: /Points<PointsAssignableMaterial>/g,
+					replacement: `Points<AssignedMaterial>`
+				}
+			]
+		}
+	]
 
-const replace_tasks = [
-	{
-		file_path: path.join(project_root_abs, `/package/components/Mesh.svelte.d.ts`),
-		todo: [
-			{
-				//regex: /get mat\(\).*}>>;/s,
-				//regex: /get mat\(\).*?};/s,
-				regex: /get mat\(\).*?>;/s, //opt2
-				//replacement: `get mat(): MeshProps<AssignedMaterial>['mat'];`
-				replacement: `get mat(): PropMat<AssignedMaterial>;`
-			},
-			{
-				//regex: /set mat\(.*}>>\);/s,
-				regex: /set mat\(.*?\);/s, // opt2
-				//replacement: `set mat(_: MeshProps<AssignedMaterial>['mat']);`
-				replacement: `set mat(_: PropMat<AssignedMaterial>);`
-			},
-			{
-				regex: /Mesh<MeshAssignableMaterial>/g,
-				replacement: `Mesh<AssignedMaterial>`
+	/**
+	 * Replace some code in generated package-files.
+	 */
+	const exec_replace_task = (task) => {
+		const rep = async () => {
+			const content = await fsp.readFile(task.file_path, "utf8")
+			//console.log(!content ? content : "content ok!")
+
+			try {
+				//console.log("CONTENT SUCCESS!")
+
+				let new_content = content
+
+				// remove wrong indent in source comments
+				//new_content = new_content.replace(/    \*/g, "*")
+
+				for (let i = 0; i < task.todo.length; i++) {
+					const todo = task.todo[i]
+					new_content = new_content.replace(todo.regex, todo.replacement)
+				}
+
+				await fsp.writeFile(task.file_path, new_content)
+			} catch (err) {
+				console.error(err)
 			}
-		]
-	},
-	{
-		file_path: path.join(project_root_abs, `/package/components/Points.svelte.d.ts`),
-		todo: [
-			{
-				//regex: /get mat\(\).*}>>;/s,
-				//regex: /get mat\(\).*?};/s,
-				regex: /get mat\(\).*?>;/s, //opt2
-				//replacement: `get mat(): PointsProps<AssignedMaterial>['mat'];`
-				replacement: `get mat(): PropMat<AssignedMaterial>;`
-			},
-			{
-				//regex: /set mat\(.*}>>\);/s,
-				regex: /set mat\(.*?\);/s, // opt2
-				//replacement: `set mat(_: PointsProps<AssignedMaterial>['mat']);`
-				replacement: `set mat(_: PropMat<AssignedMaterial>);`
-			},
-			{
-				regex: /Points<PointsAssignableMaterial>/g,
-				replacement: `Points<AssignedMaterial>`
-			}
-		]
+		}
+
+		return rep
 	}
-]
 
-/**
- * Replace some code in generated package-files.
- */
-const exec_replace_task = (task) => {
-	const rep = async () => {
-		const content = await fs.readFile(task.file_path, "utf8")
+	// --- ACCESSOR-JSDOC-COMMENTS OPTIMIZATION TASKS ---
+
+	/**
+	 * Apply comments to accessors definitions -> intellisense will show them when e.g. `comp_ref.foo` (otherwise only 'accessors' will be shown)
+	 */
+	const apply_comments_to_accessors_defs = async () => {
+		//console.log("apply_comments_to_accessors_defs!")
+
+		const all_files = []
+
+		// get './package/components/*.d.ts' file-paths
+		const folder_components = path.join(project_root_abs, `/${target_folder}/components`)
 
 		try {
-			//console.log("CONTENT SUCCESS!")
+			const files = await fsp.readdir(folder_components, { withFileTypes: false })
 
-			let new_content = content
-
-			// remove wrong indent in source comments
-			//new_content = new_content.replace(/    \*/g, "*")
-
-			for (let i = 0; i < task.todo.length; i++) {
-				const todo = task.todo[i]
-				new_content = new_content.replace(todo.regex, todo.replacement)
+			for (const file of files) {
+				//console.log(file)
+				if (file.includes(`.d.ts`)) {
+					all_files.push(`${folder_components}\\${file}`)
+				}
 			}
-
-			await fs.writeFile(task.file_path, new_content)
 		} catch (err) {
 			console.error(err)
 		}
-	}
 
-	return rep
-}
+		// get './package/components-internal/*.d.ts' file-paths
 
-// --- ACCESSOR-JSDOC-COMMENTS OPTIMIZATION TASKS ---
+		if (!using_accessors) {
+			const folder_components_internal = path.join(project_root_abs, `/${target_folder}/components-internal`)
 
-/**
- * Apply comments to accessors definitions -> intellisense will show them when e.g. `comp_ref.foo` (otherwise only 'accessors' will be shown)
- */
-const apply_comments_to_accessors_defs = async () => {
-	//console.log("apply_comments_to_accessors_defs!")
-
-	const all_files = []
-
-	// get './package/components/*.d.ts' file-paths
-	const folder_components = path.join(project_root_abs, `/package/components`)
-
-	try {
-		const files = await fs.readdir(folder_components, { withFileTypes: false })
-
-		for (const file of files) {
-			//console.log(file)
-			if (file.includes(`.d.ts`)) {
-				all_files.push(`${folder_components}\\${file}`)
-			}
-		}
-	} catch (err) {
-		console.error(err)
-	}
-
-	// get './package/components-internal/*.d.ts' file-paths
-
-	const folder_components_internal = path.join(project_root_abs, `/package/components-internal`)
-
-	try {
-		const files = await fs.readdir(folder_components_internal, { withFileTypes: false })
-		for (const file of files) {
-			//console.log(file)
-			if (file.includes(`.d.ts`)) {
-				all_files.push(`${folder_components_internal}\\${file}`)
-			}
-		}
-	} catch (err) {
-		console.error(err)
-	}
-
-	//console.log("apply_comments_to_accessors_defs! -> all files:", all_files)
-
-	for (const file of all_files) {
-		const fn_process_comments = get_process_comments_fn(file)
-		fns.push(fn_process_comments)
-	}
-}
-
-const get_process_comments_fn = (file_path) => {
-	const process_comments_fn = async () => {
-		// read file content
-		//console.log(`process_comments_fn -> ${file_path}`)
-
-		try {
-			const content = await fs.readFile(file_path, "utf8")
-			let new_content = content
-
-			// remove wrong indent in source comments
-			// EDIT: leave generated as they are
-			//new_content = new_content.replace(/ +\*/g, "    *")
-			//new_content = new_content.replace(/    \* /g, "* ")
-			//new_content = new_content.replace(/        \*/g, "*")
-
-			//always -> insert comments to accessors
-			const comments_map = new Map()
-
-			const regex_comments = /(\/\*\*.*?\*\/)( [A-Za-z].*?:)/gs // should be correct
-			let matches = new_content.match(regex_comments)
-			//console.log("matches.length", matches.length)
-
-			for (let i = 0; i < matches.length; i++) {
-				const split_match = matches[i].split("*/ ")
-				let comment = `${split_match[0]}*/`
-
-				// remove wrong indent in accessors comments only
-				comment = comment.replace(/ + \* /g, "\t * ")
-				comment = comment.replace(/ +\*\//g, "*/")
-				comment = comment.replace(/^\*\//gm, "\t*/")
-				comment = comment.replace(/\*\//g, " */")
-
-				//get name
-				const prop_name = split_match[1].replace("?:", "").replace(":", "")
-				//console.log("comment:", comment)
-				//console.log("prop_name:", prop_name)
-
-				comments_map.set(prop_name, comment)
-			}
-
-			//console.log(comments_map)
-
-			for (let [prop_name, comment] of comments_map) {
-				const str_setter = `set ${prop_name}`
-				const regex_setter = new RegExp(str_setter)
-				const test_setter = content.match(regex_setter)
-				let acc_comment
-				if (using_accessors) {
-					acc_comment = comment.replace(`/**`, `/**\n\t * ◁▶ _svelthree-component accessor_  \n\t *  \n\t *`)
-				} else {
-					acc_comment = comment.replace(
-						`/**`,
-						`/**\n\t * ◁▶ _svelthree-component method / read-only prop_  \n\t *  \n\t *`
-					)
-				}
-
-				if (test_setter) {
-					new_content = new_content.replace(`set ${prop_name}(_`, `${acc_comment}\n\tset ${prop_name}(_`)
-				} else {
-					const str_getter = `get ${prop_name}`
-					const regex_getter = new RegExp("\\b" + str_getter + "\\b")
-					const test_getter = content.match(regex_getter)
-
-					if (test_getter) {
-						new_content = new_content.replace(`get ${prop_name}()`, `${acc_comment}\n\tget ${prop_name}()`)
+			try {
+				const files = await fsp.readdir(folder_components_internal, { withFileTypes: false })
+				for (const file of files) {
+					//console.log(file)
+					if (file.includes(`.d.ts`)) {
+						all_files.push(`${folder_components_internal}\\${file}`)
 					}
 				}
+			} catch (err) {
+				console.error(err)
 			}
+		}
 
-			// remove double `/**accessor*/` before comments
-			new_content = new_content.replace(/(\/\*\*accessor\*\/)(\r\n|\r|\n)( +)(\/\*\*)/gm, "$4")
+		//console.log("apply_comments_to_accessors_defs! -> all files:", all_files)
 
-			// replace generated `/**accessor*/` with svelthree-accessors comment
-
-			new_content = new_content.replace(/\/\*\*accessor\*\//gs, "/** ◁▶ _svelthree-component accessor_ */")
-
-			//new_content = new_content.replace(/\/\*\*accessor\*\//gs, "/** ◁▶ _svelthree-component method_ */")
-
-			await fs.writeFile(file_path, new_content)
-		} catch (err) {
-			console.error(err)
+		for (const file of all_files) {
+			const fn_process_comments = get_process_comments_fn(file)
+			fns.push(fn_process_comments)
 		}
 	}
 
-	return process_comments_fn
-}
+	const get_process_comments_fn = (file_path) => {
+		const process_comments_fn = async () => {
+			// read file content
+			//console.log(`process_comments_fn -> ${file_path}`)
 
-// --- ENTRY POINT ---
+			try {
+				const content = await fsp.readFile(file_path, "utf8")
+				let new_content = content
 
-const schedule_code_replacement_tasks = true
+				// remove wrong indent in source comments
+				// EDIT: leave generated as they are
+				//new_content = new_content.replace(/ +\*/g, "    *")
+				//new_content = new_content.replace(/    \* /g, "* ")
+				//new_content = new_content.replace(/        \*/g, "*")
 
-/**
- * - Fix generic `mat` shorthand property type when using accessors:
- * 	- Replace `mat` accessors type definitions (accessor getter and setter) -> only `Mesh` and `Points`,
- * this will give us correct intellisense with e.g. `comp_ref.mat = {...}` depending on which material has
- * been asigned to the `Mesh` or `Points` component.
- * ---
- * - Optimize all accessors-jsdoc-comments:
- * 	- Copy accessors-comments from `__propDef` to `class` definition.
- * 	- Fix any comment-indentation issues (_only in `class` definition, leaving generated `__propDef` comments as they are_)
- * 	- Add svelthree-specific accessors-hint: ◁▶ _svelthree-component accessor_
- * ---
- */
-const do_postprocess = async () => {
-	console.log("🤖 SVELTHREE > post-processing package: started...")
+				//always -> insert comments to accessors
+				const comments_map = new Map()
 
-	// schedule code replacement tasks
-	if (schedule_code_replacement_tasks) {
-		console.log("🤖 SVELTHREE > post-processing package: scheduling replacement tasks...")
-		for (let i = 0; i < replace_tasks.length; i++) {
-			const task = replace_tasks[i]
-			fns.push(exec_replace_task(task))
+				const regex_comments = /(\/\*\*.*?\*\/)( [A-Za-z].*?:)/gs // should be correct
+				let matches = new_content.match(regex_comments)
+				//console.log("matches.length", matches.length)
+
+				if (matches) {
+					for (let i = 0; i < matches.length; i++) {
+						const split_match = matches[i].split("*/ ")
+						let comment = `${split_match[0]}*/`
+
+						// remove wrong indent in accessors comments only
+						comment = comment.replace(/ + \* /g, "\t * ")
+						comment = comment.replace(/ +\*\//g, "*/")
+						comment = comment.replace(/^\*\//gm, "\t*/")
+						comment = comment.replace(/\*\//g, " */")
+
+						//get name
+						const prop_name = split_match[1].replace("?:", "").replace(":", "")
+						//console.log("comment:", comment)
+						//console.log("prop_name:", prop_name)
+
+						comments_map.set(prop_name, comment)
+					}
+
+					//console.log(comments_map)
+
+					for (let [prop_name, comment] of comments_map) {
+						const str_setter = `set ${prop_name}`
+						const regex_setter = new RegExp(str_setter)
+						const test_setter = content.match(regex_setter)
+						let acc_comment
+						if (using_accessors) {
+							acc_comment = comment.replace(
+								`/**`,
+								`/**\n\t * ◁▶ _svelthree-component accessor_  \n\t *  \n\t *`
+							)
+						} else {
+							acc_comment = comment.replace(
+								`/**`,
+								`/**\n\t * ◁▶ _svelthree-component method / read-only prop_  \n\t *  \n\t *`
+							)
+						}
+
+						if (test_setter) {
+							new_content = new_content.replace(
+								`set ${prop_name}(_`,
+								`${acc_comment}\n\tset ${prop_name}(_`
+							)
+						} else {
+							const str_getter = `get ${prop_name}`
+							const regex_getter = new RegExp("\\b" + str_getter + "\\b")
+							const test_getter = content.match(regex_getter)
+
+							if (test_getter) {
+								new_content = new_content.replace(
+									`get ${prop_name}()`,
+									`${acc_comment}\n\tget ${prop_name}()`
+								)
+							}
+						}
+					}
+
+					// remove double `/**accessor*/` before comments
+					new_content = new_content.replace(/(\/\*\*accessor\*\/)(\r\n|\r|\n)( +)(\/\*\*)/gm, "$4")
+
+					// replace generated `/**accessor*/` with svelthree-accessors comment
+
+					new_content = new_content.replace(
+						/\/\*\*accessor\*\//gs,
+						"/** ◁▶ _svelthree-component accessor_ */"
+					)
+
+					//new_content = new_content.replace(/\/\*\*accessor\*\//gs, "/** ◁▶ _svelthree-component method_ */")
+
+					await fsp.writeFile(file_path, new_content)
+				}
+			} catch (err) {
+				console.error(err)
+			}
 		}
+
+		return process_comments_fn
 	}
 
-	// schedule accessors-comments optimization in `d.ts` files
-	console.log("🤖 SVELTHREE > post-processing package: scheduling accessors-comments optimization tasks...")
-	await apply_comments_to_accessors_defs()
+	// --- ENTRY POINT ---
 
-	// execute all scheduled tasks
-	console.log("🤖 SVELTHREE > post-processing package: executing all scheduled tasks...")
-	for (const fn of fns) {
-		await fn()
+	const schedule_code_replacement_tasks = true
+
+	/**
+	 * - Fix generic `mat` shorthand property type when using accessors:
+	 * 	- Replace `mat` accessors type definitions (accessor getter and setter) -> only `Mesh` and `Points`,
+	 * this will give us correct intellisense with e.g. `comp_ref.mat = {...}` depending on which material has
+	 * been asigned to the `Mesh` or `Points` component.
+	 * ---
+	 * - Optimize all accessors-jsdoc-comments:
+	 * 	- Copy accessors-comments from `__propDef` to `class` definition.
+	 * 	- Fix any comment-indentation issues (_only in `class` definition, leaving generated `__propDef` comments as they are_)
+	 * 	- Add svelthree-specific accessors-hint: ◁▶ _svelthree-component accessor_
+	 * ---
+	 */
+	const do_postprocess = async () => {
+		console.log(`🤖 SVELTHREE > post-processing package '${target_folder}': started...`)
+
+		// schedule code replacement tasks
+		if (schedule_code_replacement_tasks) {
+			console.log(`🤖 SVELTHREE > post-processing package '${target_folder}': scheduling replacement tasks...`)
+			for (let i = 0; i < replace_tasks.length; i++) {
+				const task = replace_tasks[i]
+				fns.push(exec_replace_task(task))
+			}
+		}
+
+		// schedule accessors-comments optimization in `d.ts` files
+		console.log(
+			`🤖 SVELTHREE > post-processing package '${target_folder}': scheduling accessors-comments optimization tasks...`
+		)
+		await apply_comments_to_accessors_defs()
+
+		// execute all scheduled tasks
+		console.log(`🤖 SVELTHREE > post-processing package '${target_folder}': executing all scheduled tasks...`)
+		for (const fn of fns) {
+			try {
+				await fn()
+			} catch (err) {
+				console.log(err)
+			}
+		}
+
+		console.log(`✔️  SVELTHREE > post-processing package '${target_folder}': done!\n`)
 	}
 
-	console.log("✔️  SVELTHREE > post-processing package: done!\n")
+	await do_postprocess()
 }
 
-do_postprocess()
+await postprocess_package("package", false)
+await postprocess_package("package/acc", true)
+
+console.log(`✔️✔️  SVELTHREE > post-processing "package" and "package/acc": finished!\n`)

--- a/postprocess_package.js
+++ b/postprocess_package.js
@@ -4,6 +4,8 @@ import * as path from "path"
 const project_root_abs = process.cwd()
 const fns = []
 
+const using_accessors = false
+
 // --- CODE REPLACEMENT TASKS ---
 
 const replace_tasks = [
@@ -178,10 +180,15 @@ const get_process_comments_fn = (file_path) => {
 				const str_setter = `set ${prop_name}`
 				const regex_setter = new RegExp(str_setter)
 				const test_setter = content.match(regex_setter)
-				const acc_comment = comment.replace(
-					`/**`,
-					`/**\n\t * ◁▶ _svelthree-component accessor_  \n\t *  \n\t *`
-				)
+				let acc_comment
+				if (using_accessors) {
+					acc_comment = comment.replace(`/**`, `/**\n\t * ◁▶ _svelthree-component accessor_  \n\t *  \n\t *`)
+				} else {
+					acc_comment = comment.replace(
+						`/**`,
+						`/**\n\t * ◁▶ _svelthree-component method / read-only prop_  \n\t *  \n\t *`
+					)
+				}
 
 				if (test_setter) {
 					new_content = new_content.replace(`set ${prop_name}(_`, `${acc_comment}\n\tset ${prop_name}(_`)
@@ -200,7 +207,10 @@ const get_process_comments_fn = (file_path) => {
 			new_content = new_content.replace(/(\/\*\*accessor\*\/)(\r\n|\r|\n)( +)(\/\*\*)/gm, "$4")
 
 			// replace generated `/**accessor*/` with svelthree-accessors comment
+
 			new_content = new_content.replace(/\/\*\*accessor\*\//gs, "/** ◁▶ _svelthree-component accessor_ */")
+
+			//new_content = new_content.replace(/\/\*\*accessor\*\//gs, "/** ◁▶ _svelthree-component method_ */")
 
 			await fs.writeFile(file_path, new_content)
 		} catch (err) {

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,0 +1,69 @@
+import * as fsp from "node:fs/promises"
+import * as path from "path"
+
+const get_all_files_by_extension = async (dir, ext) => {
+	let files = await fsp.readdir(dir, { withFileTypes: true })
+	return files.filter((f) => f.isFile() && path.extname(f.name) === ext).map((f) => f.name)
+}
+
+const change_paths_add_accessors = async (filename, lib_path) => {
+	const content = await fsp.readFile(`${lib_path}/acc/components/${filename}`, "utf8")
+	let new_content = content.replace(/(from "..\/)/g, `from "../../`)
+	new_content = new_content.replace(/(from ".\/)/g, `from "../`)
+
+	// revert path changes to components (except internal ones)
+	new_content = new_content.replace(/(from "..\/Canvas.svelte)/g, `from "./Canvas.svelte`)
+	new_content = new_content.replace(/(from "..\/CubeCamera.svelte)/g, `from "./CubeCamera.svelte`)
+	new_content = new_content.replace(/(from "..\/Mesh.svelte)/g, `from "./Mesh.svelte`)
+	new_content = new_content.replace(/(from "..\/Object3D.svelte)/g, `from "./Object3D.svelte`)
+	new_content = new_content.replace(/(from "..\/PerspectiveCamera.svelte)/g, `from "./PerspectiveCamera.svelte`)
+	new_content = new_content.replace(/(from "..\/OrthographicCamera.svelte)/g, `from "./OrthographicCamera.svelte`)
+
+	// add `<svelte:options accessors />`
+	new_content = `<svelte:options accessors />\n` + new_content
+
+	await fsp.writeFile(`${lib_path}/acc/components/${filename}`, new_content)
+}
+
+const create_acc_index = async (lib_path) => {
+	await fsp.copyFile(`${lib_path}/index.ts`, `${lib_path}/acc/index.ts`)
+	const content_index = await fsp.readFile(`${lib_path}/acc/index.ts`, "utf8")
+	let new_content_index = content_index.replace(/(".\/types)/g, `"../types`)
+	await fsp.writeFile(`${lib_path}/acc/index.ts`, new_content_index)
+}
+
+const do_prebuild = async () => {
+	console.log("🤖 SVELTHREE > prebuilding...")
+
+	const project_root_abs = process.cwd()
+	const lib_path = `${project_root_abs}/src/lib/`
+
+	// create temp `acc` folder
+	await fsp.mkdir(`${lib_path}/acc`)
+
+	// `src/lib/acc/components` (copy all .svelte components from `src/lib/components`)
+	await fsp.mkdir(`${lib_path}/acc/components`)
+	const all_svelte_components = await get_all_files_by_extension(`${lib_path}/components`, ".svelte")
+	//console.log(all_svelte_components)
+
+	for (let i = 0; i < all_svelte_components.length; i++) {
+		const filename = all_svelte_components[i]
+		await fsp.copyFile(`${lib_path}/components/${filename}`, `${lib_path}/acc/components/${filename}`)
+	}
+
+	// edit `*.svelte` components in `src/lib/acc/components`:
+	// - change import paths to target `src/lib/` one level up
+	// - add <svelte:options accessors> to the top
+
+	for (let i = 0; i < all_svelte_components.length; i++) {
+		const filename = all_svelte_components[i]
+		await change_paths_add_accessors(filename, lib_path)
+	}
+
+	// create and edit src/lib/acc/index.ts
+	await create_acc_index(lib_path)
+
+	console.log("✔️  SVELTHREE > prebuild finished!")
+}
+
+do_prebuild()

--- a/prebuild.js
+++ b/prebuild.js
@@ -32,6 +32,16 @@ const create_acc_index = async (lib_path) => {
 	await fsp.writeFile(`${lib_path}/acc/index.ts`, new_content_index)
 }
 
+const create_acc_stores_index = async (lib_path) => {
+	const content_index = `export * from "../../stores"`
+	await fsp.writeFile(`${lib_path}/acc/stores/index.ts`, content_index)
+}
+
+const create_acc_utils_index = async (lib_path) => {
+	const content_index = `export * from "../../utils"`
+	await fsp.writeFile(`${lib_path}/acc/utils/index.ts`, content_index)
+}
+
 const do_prebuild = async () => {
 	console.log("🤖 SVELTHREE > prebuilding...")
 
@@ -40,6 +50,12 @@ const do_prebuild = async () => {
 
 	// create temp `acc` folder
 	await fsp.mkdir(`${lib_path}/acc`)
+
+	// create temp `acc/stores` folder
+	await fsp.mkdir(`${lib_path}/acc/stores`)
+
+	// create temp `acc/utils` folder
+	await fsp.mkdir(`${lib_path}/acc/utils`)
 
 	// `src/lib/acc/components` (copy all .svelte components from `src/lib/components`)
 	await fsp.mkdir(`${lib_path}/acc/components`)
@@ -62,6 +78,10 @@ const do_prebuild = async () => {
 
 	// create and edit src/lib/acc/index.ts
 	await create_acc_index(lib_path)
+	// create and edit src/lib/acc/stores/index.ts
+	await create_acc_stores_index(lib_path)
+	// create and edit src/lib/acc/utils/index.ts
+	await create_acc_utils_index(lib_path)
 
 	console.log("✔️  SVELTHREE > prebuild finished!")
 }

--- a/src/lib/components-internal/SvelthreeInteraction.svelte
+++ b/src/lib/components-internal/SvelthreeInteraction.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!-- 
 @component

--- a/src/lib/components-internal/SvelthreeInteraction.svelte
+++ b/src/lib/components-internal/SvelthreeInteraction.svelte
@@ -96,7 +96,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		for (let i = 0; i < modifiers_arr.length; i++) {
 			const modifier_name: string = modifiers_arr[i]
 			if (!SUPPORTED_MODIFIERS_SET.has(modifier_name as SvelthreeSupportedModifier)) {
-				console.error(`SvelthreeInteraction > ERROR: modifier '${modifier_name}'`)
+				console.error(`SVELTHREE > ${c_name} > ERROR: modifier '${modifier_name}'`)
 			} else if (!valid_modifiers.includes(modifier_name as SvelthreeSupportedModifier)) {
 				valid_modifiers.push(modifier_name as SvelthreeSupportedModifier)
 			}
@@ -451,19 +451,23 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	// ---  LISTENER MANAGEMENT  UTILS ---
 
 	function has_prop_action(prop_action: string): boolean {
-		return !!parent[prop_action as keyof typeof parent]
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		return !!parent_state[prop_action]
 	}
 
 	function using_event(event_name: SvelthreeSupportedInteractionEvent): boolean {
-		return has_on_directive(event_name) || !!parent[`on_${event_name}`]
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		return has_on_directive(event_name) || !!parent_state[`on_${event_name}`]
 	}
 
 	function not_using_event(event_name: SvelthreeSupportedInteractionEvent): boolean {
-		return !has_on_directive(event_name) && !parent[`on_${event_name}`]
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		return !has_on_directive(event_name) && !parent_state[`on_${event_name}`]
 	}
 
 	function prop_action_is_simple(event_name: SvelthreeSupportedInteractionEvent): boolean {
-		return typeof parent[`on_${event_name}`] === "function"
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		return typeof parent_state[`on_${event_name}`] === "function"
 	}
 
 	function prop_action_is_complex(prop_action_handler: SvelthreePropActionHandler): boolean {
@@ -490,7 +494,8 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	// the component itself should emit the event ... isn't this already like this?
 	function add_pointer_listener(event_name: SvelthreeSupportedPointerEvent, dispatch_via_shadow_dom: boolean): void {
 		// IMPORTANT  HACKY but simple: links and buttons are being handled as directives concerning modifiers etc.!
-		if (has_on_directive(event_name) || parent.link || parent.button) {
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		if (has_on_directive(event_name) || parent_state.link || parent_state.button) {
 			if (event_not_registered(event_name, used_pointer_events_directive)) {
 				const listener_options = get_listener_options_from_modifiers_prop(event_name)
 
@@ -502,7 +507,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		}
 
-		const prop_action_handler: SvelthreePropActionHandler | undefined = parent[`on_${event_name}`]
+		const prop_action_handler: SvelthreePropActionHandler | undefined = parent_state[`on_${event_name}`]
 
 		if (prop_action_handler) {
 			if (event_not_registered(event_name, used_pointer_events_action)) {
@@ -521,7 +526,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 					set_pointer_listeners(event_name, listener_options, dispatch_via_shadow_dom, "prop_action")
 				} else {
 					console.error(
-						`SVELTHREE > SvelthreeInteraction > add_pointer_listener > Cannot process prop action for event ${event_name}, doesn't match required form.`
+						`SVELTHREE > ${c_name} > add_pointer_listener : Cannot process prop action for event ${event_name}, doesn't match required form.`
 					)
 				}
 
@@ -598,7 +603,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				if (!remove_canvas_pointermove_listener) add_canvas_pointermove_listener()
 				break
 			default:
-				console.error(`SVELTHREE > SvelthreeInteraction > Pointer event '${event_name}' not implemented!`)
+				console.error(`SVELTHREE > ${c_name} > Pointer event '${event_name}' not implemented!`)
 				break
 		}
 	}
@@ -692,7 +697,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > SvelthreeInteraction > check_pointer_moveover : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
+				`SVELTHREE > ${c_name} > check_pointer_moveover : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
 				{ shadow_dom_el }
 			)
 		}
@@ -740,7 +745,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > SvelthreeInteraction > check_pointer_overout : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
+				`SVELTHREE > ${c_name} > check_pointer_overout : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
 				{ shadow_dom_el }
 			)
 		}
@@ -763,7 +768,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > SvelthreeInteraction > check_pointer_pointerdown : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
+				`SVELTHREE > ${c_name} > check_pointer_pointerdown : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
 				{ shadow_dom_el }
 			)
 		}
@@ -786,7 +791,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > SvelthreeInteraction > check_pointer_pointerup : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
+				`SVELTHREE > ${c_name} > check_pointer_pointerup : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
 				{ shadow_dom_el }
 			)
 		}
@@ -813,7 +818,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > SvelthreeInteraction > check_pointer_click : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
+				`SVELTHREE > ${c_name} > check_pointer_click : Cannot dispatch PointerEvent '${evt.type}' via unavailable 'shadow_dom_el'!`,
 				{ shadow_dom_el }
 			)
 		}
@@ -912,7 +917,9 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 
 				break
 			default:
-				console.error(`SvelthreeInteraction > pointerevents_handler > no such 'render_mode' -> ${render_mode}!`)
+				console.error(
+					`SVELTHREE > ${c_name} > pointerevents_handler : no such 'render_mode' -> ${render_mode}!`
+				)
 				break
 		}
 	}
@@ -951,6 +958,8 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	/*  FOCUS Event   SHADOW DOM Event LISTENER -> SHADOW DOM Event HANDLER  */
 
 	function add_focus_listener(event_name: SvelthreeSupportedFocusEvent): void {
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+
 		if (has_on_directive(event_name)) {
 			if (event_not_registered(event_name, used_focus_events_directive)) {
 				const listener_options = get_listener_options_from_modifiers_prop(event_name)
@@ -962,7 +971,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		}
 
-		const prop_action_handler: SvelthreePropActionHandler | undefined = parent[`on_${event_name}`]
+		const prop_action_handler: SvelthreePropActionHandler | undefined = parent_state[`on_${event_name}`]
 
 		if (prop_action_handler) {
 			if (event_not_registered(event_name, used_focus_events_action)) {
@@ -982,7 +991,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 					set_focus_listener(event_name, listener_options, "prop_action")
 				} else {
 					console.error(
-						`SVELTHREE > SvelthreeInteraction > add_focus_listener > Cannot process prop action for event ${event_name}, doesn't match required form.`
+						`SVELTHREE > ${c_name} > add_focus_listener : Cannot process prop action for event ${event_name}, doesn't match required form.`
 					)
 				}
 
@@ -1052,7 +1061,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				dispatch_focusevent_intersection_indep(evt)
 				break
 			default:
-				console.error(`SvelthreeInteraction > focusevents_handler > no such 'render_mode' -> ${render_mode}!`)
+				console.error(`SVELTHREE > ${c_name} > focusevents_handler : no such 'render_mode' -> ${render_mode}!`)
 				break
 		}
 	}
@@ -1078,6 +1087,8 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	/*  KEYBOARD Event   SHADOW DOM Event LISTENER -> SHADOW DOM Event HANDLER  */
 
 	function add_keyboard_listener(event_name: SvelthreeSupportedKeyboardEvent): void {
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+
 		if (has_on_directive(event_name)) {
 			if (event_not_registered(event_name, used_keyboard_events_directive)) {
 				const listener_options = get_listener_options_from_modifiers_prop(event_name)
@@ -1090,7 +1101,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		}
 
-		const prop_action_handler: SvelthreePropActionHandler | undefined = parent[`on_${event_name}`]
+		const prop_action_handler: SvelthreePropActionHandler | undefined = parent_state[`on_${event_name}`]
 
 		if (prop_action_handler) {
 			if (event_not_registered(event_name, used_keyboard_events_action)) {
@@ -1109,7 +1120,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 					set_keyboard_listener(event_name, listener_options, "prop_action")
 				} else {
 					console.error(
-						`SVELTHREE > SvelthreeInteraction > add_keyboard_listener > Cannot process prop action for event ${event_name}, doesn't match required form.`
+						`SVELTHREE > ${c_name} > add_keyboard_listener : Cannot process prop action for event ${event_name}, doesn't match required form.`
 					)
 				}
 
@@ -1188,7 +1199,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 					add_canvas_keypress_listener_directive()
 				break
 			default:
-				console.error(`SVELTHREE > SvelthreeInteraction > Keyboard event '${event_name}' not implemented!`)
+				console.error(`SVELTHREE > ${c_name} : Keyboard event '${event_name}' not implemented!`)
 				break
 		}
 	}
@@ -1275,7 +1286,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				canvas_component.default_keyboard_events_handler[evt.type](evt)
 			} else {
 				console.error(
-					"SVELTHREE > SvelthreeInteraction > keyboardevents_handler > Couldn't call 'canvas_component.default_keyboard_events_handler[evt.type](evt)', 'canvas_component' is not available!",
+					`SVELTHREE > ${c_name} > keyboardevents_handler : Couldn't call 'canvas_component.default_keyboard_events_handler[evt.type](evt)', 'canvas_component' is not available!`,
 					{ canvas_component }
 				)
 			}
@@ -1283,7 +1294,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			if (cancel_or_stop_propagation_fn) cancel_or_stop_propagation_fn(evt)
 		} else if (is_default_keyboard_handler_specified === null) {
 			console.error(
-				"SVELTHREE > SvelthreeInteraction > keyboardevents_handler > 'is_default_keyboard_handler_specified' is 'null', means 'canvas_component' is not available!",
+				`SVELTHREE > ${c_name} > keyboardevents_handler : 'is_default_keyboard_handler_specified' is 'null', means 'canvas_component' is not available!`,
 				{ canvas_component }
 			)
 		}
@@ -1301,7 +1312,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				break
 			default:
 				console.error(
-					`SvelthreeInteraction > keyboardevents_handler > no such 'render_mode' -> ${render_mode}!`
+					`SVELTHREE > ${c_name} > keyboardevents_handler : no such 'render_mode' -> ${render_mode}!`
 				)
 				break
 		}
@@ -1315,7 +1326,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			)
 		} else {
 			console.error(
-				"SVELTHREE > SvelthreeInteraction > default_keyboard_handler_specified : 'canvas_component' not available!",
+				`SVELTHREE > ${c_name} > default_keyboard_handler_specified : 'canvas_component' not available!`,
 				{ canvas_component }
 			)
 			return false
@@ -1422,6 +1433,8 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	// COOL!  Multiple `on:` directives WILL be triggered as expected.
 
 	$: if ((r_add_on_init && !r_added_on_init) || (update_listeners && interactionEnabled)) {
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+
 		r_added_on_init = true
 		update_listeners = false
 
@@ -1431,7 +1444,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 
 		// will be queued in mode "always"
 		// will be dispatsched immediately in mode "auto" -> see 'pointerevents_handler'
-		if (using_event("click") || parent.button || parent.link) add_pointer_listener("click", true)
+		if (using_event("click") || parent_state.button || parent_state.link) add_pointer_listener("click", true)
 		if (using_event("pointerup")) add_pointer_listener("pointerup", true)
 		if (using_event("pointerdown")) add_pointer_listener("pointerdown", true)
 		//if (using_event("pointerenter")) add_pointer_listener("pointerenter") ->  DEPRECATED  same as 'pointerover'
@@ -1462,7 +1475,8 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 
 		// --- REMOVE / UNREGISTER UNUSED EVENTS / LISTENERS ---
 
-		if (not_using_event("click") && !parent.button && !parent.link) completely_remove_pointer_listener("click")
+		if (not_using_event("click") && !parent_state.button && !parent_state.link)
+			completely_remove_pointer_listener("click")
 		if (not_using_event("pointerup")) completely_remove_pointer_listener("pointerup")
 		if (not_using_event("pointerdown")) completely_remove_pointer_listener("pointerdown")
 		//if (not_using_event("pointerenter")) completely_remove_pointer_listener("pointerenter") ->  DEPRECATED  same as 'pointerover'
@@ -1519,15 +1533,18 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	 * cursor will not change (_cursor changes on `interact: true` + `block: false` only_).
 	 */
 	function set_block_status(): void {
+		let parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+
 		//cursor will change on `interact: true` + `block: false`
 		if (verbose && log_dev)
 			console.debug(
-				"SvelthreeInteraction > set_block_status > used_pointer_events.size:",
+				`SVELTHREE > ${c_name} > set_block_status : used_pointer_events.size:`,
 				used_pointer_events.size
 			)
 		if (used_pointer_events.size === 0) {
 			// cursor will not change
-			parent.block = true
+			parent.$set({ block: true })
+			parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
 			if (obj) {
 				obj.userData.block = true
 				if (verbose && log_dev) {
@@ -1535,7 +1552,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 						`SVELTHREE > ${c_name} > set_block_status : parent.block, obj.userData.block -> true`,
 						{
 							parent,
-							parent_block: parent.block,
+							parent_block: parent_state.block,
 							obj_userData_block: obj.userData.block
 						}
 					)
@@ -1548,11 +1565,12 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			// cursor will change
-			parent.block = false
+			parent.$set({ block: true })
+			parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
 			if (verbose && log_dev) {
 				console.debug(`SVELTHREE > ${c_name} > set_block_status : parent.block -> false`, {
 					parent,
-					parent_block: parent.block
+					parent_block: parent_state.block
 				})
 			}
 			//obj.userData.block = false
@@ -1582,7 +1600,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > register_event : Cannot register '${event_name}' Event on 'Canvas' component, 'canvas_component' not available!`,
+				`SVELTHREE > > ${c_name} > register_event : Cannot register '${event_name}' Event on 'Canvas' component, 'canvas_component' not available!`,
 				{ canvas_component }
 			)
 		}
@@ -1657,7 +1675,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 					break
 				default:
 					console.error(
-						`SVELTHREE > SvelthreeInteraction > completely_remove_keyboard_listener > Keyboard event '${event_name}' not implemented!`
+						`SVELTHREE > ${c_name} > completely_remove_keyboard_listener : Keyboard event '${event_name}' not implemented!`
 					)
 					break
 			}
@@ -1669,7 +1687,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				shadow_dom_el.removeEventListener(event_name, keyboardevents_handler_directive as EventListener, true)
 			} else {
 				console.error(
-					`SVELTHREE > SvelthreeInteraction > completely_remove_keyboard_listener > Cannot remove listener from unavailable 'shadow_dom_el'!`,
+					`SVELTHREE > ${c_name} > completely_remove_keyboard_listener : Cannot remove listener from unavailable 'shadow_dom_el'!`,
 					{ shadow_dom_el }
 				)
 			}
@@ -1687,7 +1705,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			canvas_component.unregister_canvas_listener(event_name)
 		} else {
 			console.error(
-				`SVELTHREE > unregister_keyboard_event : Cannot unregister '${event_name}' Event on 'Canvas' component, 'canvas_component' not available!`,
+				`SVELTHREE > ${c_name} > unregister_keyboard_event : Cannot unregister '${event_name}' Event on 'Canvas' component, 'canvas_component' not available!`,
 				{ canvas_component }
 			)
 		}
@@ -1709,7 +1727,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				shadow_dom_el.removeEventListener(event_name, focusevents_handler_directive as EventListener, false)
 			} else {
 				console.error(
-					`SVELTHREE > SvelthreeInteraction > completely_remove_focus_listener > Cannot remove '${event_name}' listener from unavailable 'shadow_dom_el'!`,
+					`SVELTHREE > ${c_name} > completely_remove_focus_listener : Cannot remove '${event_name}' listener from unavailable 'shadow_dom_el'!`,
 					{ shadow_dom_el }
 				)
 			}
@@ -1748,7 +1766,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 					break
 				default:
 					console.error(
-						`SVELTHREE > SvelthreeInteraction > completely_remove_pointer_listener > Pointer event '${event_name}' not implemented!`
+						`SVELTHREE > ${c_name} > completely_remove_pointer_listener : Pointer event '${event_name}' not implemented!`
 					)
 					break
 			}
@@ -1760,7 +1778,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 				shadow_dom_el.removeEventListener(event_name, pointerevents_handler_directive as EventListener, true)
 			} else {
 				console.error(
-					`SVELTHREE > SvelthreeInteraction > completely_remove_pointer_listener > Cannot remove '${event_name}' listener from unavailable 'shadow_dom_el'!`,
+					`SVELTHREE > ${c_name} > completely_remove_pointer_listener : Cannot remove '${event_name}' listener from unavailable 'shadow_dom_el'!`,
 					{ shadow_dom_el }
 				)
 			}
@@ -1786,7 +1804,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 			}
 		} else {
 			console.error(
-				`SVELTHREE > unregister_pointer_event : Cannot unregister '${event_name}' Event on 'Canvas' component, 'canvas_component' not available!`,
+				`SVELTHREE > ${c_name} > unregister_pointer_event : Cannot unregister '${event_name}' Event on 'Canvas' component, 'canvas_component' not available!`,
 				{ canvas_component }
 			)
 		}
@@ -1804,22 +1822,30 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 
 	function dispatch_prop_action(action_name: string, e_type: string, detail: SvelthreeInteractionEventDetail) {
 		const evt = new CustomEvent(e_type, { detail })
-		const action = parent[action_name as keyof typeof parent]
+		const parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+		const action = parent_state[action_name]
 
 		if (action) {
-			if (typeof parent[action_name as keyof typeof parent] === "function") {
+			if (typeof action === "function") {
 				action(evt)
-			} else if (parent[action_name as keyof typeof parent].length) {
-				action[0](evt)
+			} else if (Array.isArray(action)) {
+				if (typeof action[0] === "function") {
+					action[0](evt)
+				} else {
+					console.error(
+						`SVELTHREE > ${c_name} > dispatch_prop_action : provided '${action_name}' action prop is not of valid type! First item in the provided Array should be a function!`,
+						{ action_name, action }
+					)
+				}
 			} else {
 				console.error(
-					`SVELTHREE > SvelthreeInteraction > dispatch_prop_action : provided '${action_name}' action prop is not of valid type!`,
+					`SVELTHREE > ${c_name} > dispatch_prop_action : provided '${action_name}' action prop is not of valid type!`,
 					{ action_name, action }
 				)
 			}
 		} else {
 			console.error(
-				`SVELTHREE > SvelthreeInteraction > dispatch_prop_action : '${action_name}' action prop is not available!`,
+				`SVELTHREE > ${c_name} > dispatch_prop_action : '${action_name}' action prop is not available!`,
 				{ action_name, action }
 			)
 		}

--- a/src/lib/components-internal/SvelthreeInteraction.svelte
+++ b/src/lib/components-internal/SvelthreeInteraction.svelte
@@ -54,7 +54,6 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	const verbose: boolean = verbose_mode()
 
 	export let log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined = undefined
-	//export let log_rs = false
 	export let log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined = undefined
 
 	export let interactionEnabled: boolean | undefined

--- a/src/lib/components-internal/SvelthreeInteraction.svelte
+++ b/src/lib/components-internal/SvelthreeInteraction.svelte
@@ -866,7 +866,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		evt: PointerEvent,
 		cancel_or_stop_propagation_fn: ((evt: PointerEvent | FocusEvent | KeyboardEvent) => void) | null = null
 	): void {
-		const render_mode = store?.rendererComponent?.mode
+		const render_mode = store?.rendererComponent?.get_mode()
 
 		// TODO  `gotpointercapture`, `lostpointercapture` & `pointercancel` events usage needs to be explored!
 
@@ -1039,7 +1039,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		evt: FocusEvent,
 		cancel_or_stop_propagation_fn: (evt: PointerEvent | FocusEvent | KeyboardEvent) => void
 	): void {
-		const render_mode = store?.rendererComponent?.mode
+		const render_mode = store?.rendererComponent?.get_mode()
 
 		cancel_or_stop_propagation_fn(evt)
 
@@ -1267,7 +1267,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		evt: KeyboardEvent,
 		cancel_or_stop_propagation_fn: ((evt: PointerEvent | FocusEvent | KeyboardEvent) => void) | null
 	): void {
-		const render_mode = store?.rendererComponent?.mode
+		const render_mode = store?.rendererComponent?.get_mode()
 
 		//  IMPORTANT  //
 		// any specified `default_keyboard_events_handler` for the received keyboard event
@@ -1504,17 +1504,17 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		if (obj) {
 			if (store) {
 				if (!obj.userData.block) {
-					if (store.rendererComponent?.mode === "always" && !remove_interaction_2_listener) {
+					if (store.rendererComponent?.get_mode() === "always" && !remove_interaction_2_listener) {
 						add_interaction_2_listener()
 					}
 				} else {
-					if (store.rendererComponent?.mode === "always" && remove_interaction_2_listener) {
+					if (store.rendererComponent?.get_mode() === "always" && remove_interaction_2_listener) {
 						remove_interaction_2_listener()
 						remove_interaction_2_listener = null
 					}
 				}
 
-				if (store.rendererComponent?.mode === "always" && !remove_interaction_3_listener) {
+				if (store.rendererComponent?.get_mode() === "always" && !remove_interaction_3_listener) {
 					add_interaction_3_listener()
 				}
 			}

--- a/src/lib/components-internal/SvelthreeInteraction.svelte
+++ b/src/lib/components-internal/SvelthreeInteraction.svelte
@@ -444,22 +444,22 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	// ---  LISTENER MANAGEMENT  UTILS ---
 
 	function has_prop_action(prop_action: string): boolean {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
-		return !!parent_state[prop_action]
+		const parent_state = parent.state()
+		return !!parent_state[prop_action as keyof typeof parent_state]
 	}
 
 	function using_event(event_name: SvelthreeSupportedInteractionEvent): boolean {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		const parent_state = parent.state()
 		return has_on_directive(event_name) || !!parent_state[`on_${event_name}`]
 	}
 
 	function not_using_event(event_name: SvelthreeSupportedInteractionEvent): boolean {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		const parent_state = parent.state()
 		return !has_on_directive(event_name) && !parent_state[`on_${event_name}`]
 	}
 
 	function prop_action_is_simple(event_name: SvelthreeSupportedInteractionEvent): boolean {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		const parent_state = parent.state()
 		return typeof parent_state[`on_${event_name}`] === "function"
 	}
 
@@ -487,7 +487,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	// the component itself should emit the event ... isn't this already like this?
 	function add_pointer_listener(event_name: SvelthreeSupportedPointerEvent, dispatch_via_shadow_dom: boolean): void {
 		// IMPORTANT  HACKY but simple: links and buttons are being handled as directives concerning modifiers etc.!
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		const parent_state = parent.state()
 		if (has_on_directive(event_name) || parent_state.link || parent_state.button) {
 			if (event_not_registered(event_name, used_pointer_events_directive)) {
 				const listener_options = get_listener_options_from_modifiers_prop(event_name)
@@ -951,7 +951,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	/*  FOCUS Event   SHADOW DOM Event LISTENER -> SHADOW DOM Event HANDLER  */
 
 	function add_focus_listener(event_name: SvelthreeSupportedFocusEvent): void {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		const parent_state = parent.state()
 
 		if (has_on_directive(event_name)) {
 			if (event_not_registered(event_name, used_focus_events_directive)) {
@@ -1080,7 +1080,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	/*  KEYBOARD Event   SHADOW DOM Event LISTENER -> SHADOW DOM Event HANDLER  */
 
 	function add_keyboard_listener(event_name: SvelthreeSupportedKeyboardEvent): void {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: SvelthreePropActionHandler }
+		const parent_state = parent.state()
 
 		if (has_on_directive(event_name)) {
 			if (event_not_registered(event_name, used_keyboard_events_directive)) {
@@ -1426,7 +1426,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	// COOL!  Multiple `on:` directives WILL be triggered as expected.
 
 	$: if ((r_add_on_init && !r_added_on_init) || (update_listeners && interactionEnabled)) {
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+		const parent_state = parent.state()
 
 		r_added_on_init = true
 		update_listeners = false
@@ -1526,7 +1526,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 	 * cursor will not change (_cursor changes on `interact: true` + `block: false` only_).
 	 */
 	function set_block_status(): void {
-		let parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+		let parent_state = parent.state()
 
 		//cursor will change on `interact: true` + `block: false`
 		if (verbose && log_dev)
@@ -1537,7 +1537,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		if (used_pointer_events.size === 0) {
 			// cursor will not change
 			parent.$set({ block: true })
-			parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+			parent_state = parent.state()
 			if (obj) {
 				obj.userData.block = true
 				if (verbose && log_dev) {
@@ -1559,7 +1559,7 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 		} else {
 			// cursor will change
 			parent.$set({ block: true })
-			parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
+			parent_state = parent.state()
 			if (verbose && log_dev) {
 				console.debug(`SVELTHREE > ${c_name} > set_block_status : parent.block -> false`, {
 					parent,
@@ -1815,8 +1815,8 @@ This is a **svelthree** _SvelthreeInteraction_ Component.
 
 	function dispatch_prop_action(action_name: string, e_type: string, detail: SvelthreeInteractionEventDetail) {
 		const evt = new CustomEvent(e_type, { detail })
-		const parent_state = parent.$capture_state() as unknown as { [key: string]: unknown }
-		const action = parent_state[action_name]
+		const parent_state = parent.state()
+		const action = parent_state[action_name as keyof typeof parent_state] as unknown
 
 		if (action) {
 			if (typeof action === "function") {

--- a/src/lib/components-internal/SvelthreeInteraction.svelte
+++ b/src/lib/components-internal/SvelthreeInteraction.svelte
@@ -1,9 +1,3 @@
-<!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
 <!-- 
 @component
 This is a **svelthree** _SvelthreeInteraction_ Component.  

--- a/src/lib/components-internal/SvelthreeLightWithShadow.svelte
+++ b/src/lib/components-internal/SvelthreeLightWithShadow.svelte
@@ -1,9 +1,3 @@
-<!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
 <!-- 
 @component
 This is an internal _SvelthreeLightWithShadow_ Component.

--- a/src/lib/components-internal/SvelthreeLightWithShadow.svelte
+++ b/src/lib/components-internal/SvelthreeLightWithShadow.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!-- 
 @component

--- a/src/lib/components/AmbientLight.svelte
+++ b/src/lib/components/AmbientLight.svelte
@@ -3,6 +3,37 @@
 **svelthree** _AmbientLight_ Component.
 AmbientLight cannot be used to cast shadows as it doesn't have a direction. Position is also irrelevant. See https://threejs.org/docs/#api/en/lights/AmbientLight.
 [ tbd ]  Link to Docs. -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./AmbientLight.svelte").default
+
+	export interface IStateAmbientLight {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly light: THREE_AmbientLight | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_AmbientLight> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly props: PropsAmbientLight | undefined
+		readonly color: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly intensity: number | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -37,7 +68,6 @@ AmbientLight cannot be used to cast shadows as it doesn't have a direction. Posi
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./AmbientLight.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -697,6 +727,44 @@ AmbientLight cannot be used to cast shadows as it doesn't have a direction. Posi
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateAmbientLight> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					light,
+					name,
+					params,
+					tabindex,
+					aria,
+					mau,
+					props,
+					color,
+					intensity,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/AmbientLight.svelte
+++ b/src/lib/components/AmbientLight.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/AmbientLight.svelte
+++ b/src/lib/components/AmbientLight.svelte
@@ -685,7 +685,7 @@ AmbientLight cannot be used to cast shadows as it doesn't have a direction. Posi
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/AmbientLight.svelte
+++ b/src/lib/components/AmbientLight.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _AmbientLight_ Component.
 AmbientLight cannot be used to cast shadows as it doesn't have a direction. Position is also irrelevant. See https://threejs.org/docs/#api/en/lights/AmbientLight.

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -3,6 +3,43 @@
 This is a **svelthree** _Canvas_ Component.  
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type SvelthreeDefaultKeyboardListenerHost = "window" | "canvas" | "document" | undefined
+	type CurrentComponentType = import("./Canvas.svelte").default
+	interface DefaultKeyboardEventsListener {
+		keydown?: (e: KeyboardEvent) => void
+		keyup?: (e: KeyboardEvent) => void
+		keypress?: (e: KeyboardEvent) => void
+	}
+
+	export interface IStateCanvas {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly id: string
+		readonly style: string | undefined
+		readonly change_cursor: boolean
+		readonly interactive: boolean | undefined
+		readonly pointer_listener_options: { capture: boolean }
+		readonly on_pointerevents: ((e: PointerEvent) => void) | undefined
+		readonly default_keyboard_listeners_host: SvelthreeDefaultKeyboardListenerHost
+		readonly default_keyboardevents_listener: DefaultKeyboardEventsListener | undefined
+		readonly keyboard_listener_options: { capture: boolean }
+		readonly on_keyboardevents: ((e: KeyboardEvent) => void) | undefined
+		readonly raycast: RaycastArray
+		readonly recursive: boolean
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	// #region --- Imports
 
@@ -37,7 +74,6 @@ This is a **svelthree** _Canvas_ Component.
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./Canvas.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -109,8 +145,6 @@ This is a **svelthree** _Canvas_ Component.
 	 */
 	export let on_pointerevents: ((e: PointerEvent) => void) | undefined = undefined
 
-	type SvelthreeDefaultKeyboardListenerHost = "window" | "canvas" | "document" | undefined
-
 	/**
 	 * Specifies where to add `KeyboardEvent` listeners to.
 	 *
@@ -145,11 +179,6 @@ This is a **svelthree** _Canvas_ Component.
 	export let default_keyboard_listeners_host: SvelthreeDefaultKeyboardListenerHost = "window"
 	let keyboard_listeners_host: Window | Document | HTMLCanvasElement | undefined = undefined
 
-	interface DefaultKeyboardEventsListener {
-		keydown?: (e: KeyboardEvent) => void
-		keyup?: (e: KeyboardEvent) => void
-		keypress?: (e: KeyboardEvent) => void
-	}
 	/**
 	 * Allows specifying a different handlers for _global_ `"keydown"`, `"keyup"` and `"keypress"` events.
 	 * If defined, an additional listener will be added to the `default_keyboard_listeners_host` (_default: `window`_).
@@ -1061,6 +1090,42 @@ This is a **svelthree** _Canvas_ Component.
 					}
 			  }
 	)
+	export const state = (): Partial<IStateCanvas> => {
+		return {}
+	}
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					id,
+					style,
+					change_cursor,
+					interactive,
+					pointer_listener_options,
+					on_pointerevents,
+					default_keyboard_listeners_host,
+					default_keyboardevents_listener,
+					keyboard_listener_options,
+					on_keyboardevents,
+					raycast,
+					recursive,
+					tabindex,
+					aria,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
+	}
 </script>
 
 <canvas {id} data-kind="svelthree_canvas" bind:this={c} width={w} height={h} {style} class={clazz} />

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,9 +1,3 @@
-<!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors />
-
 <!-- 
 @component
 This is a **svelthree** _Canvas_ Component.  

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -65,8 +65,8 @@ This is a **svelthree** _Canvas_ Component.
 
 	// #region --- Optional Attributes
 
-	/** RECONSIDER  `name` attribute is currently unused, but could be somehow useful in future. */
-	// export let name: string = undefined
+	/** The `id` of the `Canvas` DOMElement. */
+	export let id = ""
 
 	export let style: string | undefined = undefined
 	let clazz: string | undefined = undefined
@@ -1063,7 +1063,7 @@ This is a **svelthree** _Canvas_ Component.
 	)
 </script>
 
-<canvas data-kind="svelthree_canvas" bind:this={c} width={w} height={h} {style} class={clazz} />
+<canvas {id} data-kind="svelthree_canvas" bind:this={c} width={w} height={h} {style} class={clazz} />
 <!-- IMPORTANT  any objects with 'tabindex' specified will receive focus -->
 <div bind:this={sh_root} data-kind="svelthree_shadow_dom_root" style="height: 0; width: 0; overflow: hidden;">
 	<slot />

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -90,7 +90,7 @@ This is a **svelthree** _Canvas_ Component.
 	 *
 	 *  TODO : this is just a basic implementation, not much tested ( _other use cases_ ) yet.
 	 * */
-	export let pointer_listener_options = { capture: true }
+	export let pointer_listener_options: { capture: boolean } = { capture: true }
 	const pointer_capture = pointer_listener_options.capture
 
 	/**
@@ -180,7 +180,7 @@ This is a **svelthree** _Canvas_ Component.
 	 *
 	 *  TODO : this is just a basic implementation, not much tested ( _other use cases_ ) yet.
 	 * */
-	export let keyboard_listener_options = { capture: true }
+	export let keyboard_listener_options: { capture: boolean } = { capture: true }
 	const keyboard_capture = keyboard_listener_options.capture
 
 	/**

--- a/src/lib/components/CubeCamera.svelte
+++ b/src/lib/components/CubeCamera.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/CubeCamera.svelte
+++ b/src/lib/components/CubeCamera.svelte
@@ -3,6 +3,66 @@
 **svelthree** _CubeCamera_ Component.
 Renders a `CubeMap` which can be used with **non-PBR** materials having an `.envMap` property. `CubeCamera` is currently not working with PBR materials like `MeshStandardMaterial` (see [22236](https://github.com/mrdoob/three.js/issues/22236)).     
 [ tbd ]  Link to Docs. -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./CubeCamera.svelte").default
+
+	export interface IStateCubeCamera {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly dynamic: boolean
+		readonly bind_pos:
+			| MeshSvelthreeComponent<MeshAssignableMaterial>
+			| Object3DSvelthreeComponent
+			| Object3D
+			| undefined
+		readonly bind_pos_offset: Vector3 | undefined
+		readonly hide:
+			| (MeshSvelthreeComponent<MeshAssignableMaterial> | Object3DSvelthreeComponent | Object3D)[]
+			| undefined
+		readonly bind_tex: MeshPhongMaterial | MeshBasicMaterial | MeshLambertMaterial | undefined
+		readonly texture: CubeTexture | undefined
+		readonly is_floor: boolean
+		readonly camera: THREE_CubeCamera | undefined | null
+		readonly renderTarget: WebGLCubeRenderTarget | undefined
+		readonly name: string | undefined
+		readonly renderTargetParams: ConstructorParameters<typeof WebGLCubeRenderTarget> | undefined
+		readonly params: RemoveLast<ConstructorParameters<typeof THREE_CubeCamera>> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly renderTargetOptions: PropWebGLRenderTargetOptions | undefined
+		readonly renderTargetProps: PropsWebGLCubeRenderTarget | undefined
+		readonly props: PropsCubeCamera | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -61,7 +121,6 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./CubeCamera.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -477,7 +536,7 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 				if (bound_pos) {
 					if (Object.hasOwn(bound_pos, "$$")) {
 						const bound_comp = bound_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
-						const bound_comp_state = bound_comp.$capture_state() as unknown as { [key: string]: unknown }
+						const bound_comp_state = bound_comp.state()
 						op_mat = bound_comp_state.material as MaterialWithEnvMap
 					} else {
 						const op = bound_pos as Mesh
@@ -597,8 +656,8 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 					if (Object.hasOwn(bind_pos, "$$")) {
 						if (Object.hasOwn((bind_pos as SvelteComponentDev).$$, "mat")) {
 							// use `mat` to set `envMap` if the component has `mat` prop defined
-							const comp = bind_pos as SvelteComponentDev
-							const comp_state = comp.$capture_state() as unknown as { [key: string]: unknown }
+							const comp = bind_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
+							const comp_state = comp.state()
 							const material = comp_state.material as MaterialWithEnvMap
 							if (Object.hasOwn(material, "envMap")) {
 								const mat = comp_state.mat as PropMat<MaterialWithEnvMap>
@@ -612,8 +671,8 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 							}
 						} else if (Object.hasOwn(bind_pos, "material")) {
 							// set `envMap` directly on `material` if the component has `material` prop defined
-							const comp = bind_pos as SvelteComponentDev
-							const comp_state = comp.$capture_state() as unknown as { [key: string]: unknown }
+							const comp = bind_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
+							const comp_state = comp.state()
 							const material = comp_state.material as MaterialWithEnvMap
 							if (Object.hasOwn(material, "envMap")) {
 								material.envMap = camera.renderTarget.texture
@@ -1189,6 +1248,60 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateCubeCamera> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					dynamic,
+					bind_pos,
+					bind_pos_offset,
+					hide,
+					bind_tex,
+					texture,
+					is_floor,
+					camera,
+					renderTarget,
+					name,
+					renderTargetParams,
+					params,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					renderTargetOptions,
+					renderTargetProps,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/CubeCamera.svelte
+++ b/src/lib/components/CubeCamera.svelte
@@ -1162,7 +1162,7 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/CubeCamera.svelte
+++ b/src/lib/components/CubeCamera.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _CubeCamera_ Component.
 Renders a `CubeMap` which can be used with **non-PBR** materials having an `.envMap` property. `CubeCamera` is currently not working with PBR materials like `MeshStandardMaterial` (see [22236](https://github.com/mrdoob/three.js/issues/22236)).     

--- a/src/lib/components/CubeCamera.svelte
+++ b/src/lib/components/CubeCamera.svelte
@@ -468,9 +468,23 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 
 			camera_updated = true
 
+			// TODO  works, but review / make better
 			if (!bind_tex) {
-				const op = bound_pos as Mesh
-				const op_mat = op.material as MaterialWithEnvMap
+				// material of our parent (component or Mesh)
+				// TODO  what about Points?
+				let op_mat
+
+				if (bound_pos) {
+					if (Object.hasOwn(bound_pos, "$$")) {
+						const bound_comp = bound_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
+						const bound_comp_state = bound_comp.$capture_state() as unknown as { [key: string]: unknown }
+						op_mat = bound_comp_state.material as MaterialWithEnvMap
+					} else {
+						const op = bound_pos as Mesh
+						op_mat = op.material as MaterialWithEnvMap
+					}
+				}
+
 				if (op_mat && Object.hasOwn(op_mat, "envMap")) {
 					op_mat.envMap = camera.renderTarget.texture
 				}
@@ -572,6 +586,7 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 		}
 	}
 
+	// TODO  works, but review / make better
 	function update_texture_bindings() {
 		if (camera) {
 			if (bind_tex) {

--- a/src/lib/components/CubeCamera.svelte
+++ b/src/lib/components/CubeCamera.svelte
@@ -99,14 +99,8 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 	import { get_root_scene } from "../utils/SceneUtils"
 	import { Vector3 } from "three"
 	import type { CubeTexture, WebGLRenderer, Camera, Mesh } from "three"
-	import type {
-		Material,
-		MeshBasicMaterialParameters,
-		MeshPhongMaterial,
-		MeshBasicMaterial,
-		MeshLambertMaterial
-	} from "three"
-	import type { RemoveLast, MeshAssignableMaterial } from "../types/types-extra"
+	import type { MeshPhongMaterial, MeshBasicMaterial, MeshLambertMaterial } from "three"
+	import type { RemoveLast, MeshAssignableMaterial, MeshMaterialWithEnvMap } from "../types/types-extra"
 	import type { default as MeshSvelthreeComponent } from "./Mesh.svelte"
 	import type { default as Object3DSvelthreeComponent } from "./Object3D.svelte"
 	import type { StoreBody } from "../types/types-extra"
@@ -485,10 +479,6 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 		}
 	}
 
-	interface MaterialWithEnvMap extends Material {
-		envMap?: MeshBasicMaterialParameters["envMap"]
-	}
-
 	/** Called internally from WebGLRenderer component if `dynamic` is `true` (default). Can also be called directly if `dynamic` is `false`. */
 	export const update_cubecam = () => {
 		// TODO  FEATURE: There could be some logic if camera.parent is scene (&& NOT the root scene) traversing all objects in a scene,
@@ -537,10 +527,10 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 					if (Object.hasOwn(bound_pos, "$$")) {
 						const bound_comp = bound_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
 						const bound_comp_state = bound_comp.state()
-						op_mat = bound_comp_state.material as MaterialWithEnvMap
+						op_mat = bound_comp_state.material as MeshMaterialWithEnvMap
 					} else {
 						const op = bound_pos as Mesh
-						op_mat = op.material as MaterialWithEnvMap
+						op_mat = op.material as MeshMaterialWithEnvMap
 					}
 				}
 
@@ -658,9 +648,9 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 							// use `mat` to set `envMap` if the component has `mat` prop defined
 							const comp = bind_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
 							const comp_state = comp.state()
-							const material = comp_state.material as MaterialWithEnvMap
+							const material = comp_state.material as MeshMaterialWithEnvMap
 							if (Object.hasOwn(material, "envMap")) {
-								const mat = comp_state.mat as PropMat<MaterialWithEnvMap>
+								const mat = comp_state.mat as PropMat<MeshMaterialWithEnvMap>
 								mat.envMap = camera.renderTarget.texture
 								comp.$set({ mat })
 							} else {
@@ -673,7 +663,7 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 							// set `envMap` directly on `material` if the component has `material` prop defined
 							const comp = bind_pos as MeshSvelthreeComponent<MeshAssignableMaterial>
 							const comp_state = comp.state()
-							const material = comp_state.material as MaterialWithEnvMap
+							const material = comp_state.material as MeshMaterialWithEnvMap
 							if (Object.hasOwn(material, "envMap")) {
 								material.envMap = camera.renderTarget.texture
 								material.needsUpdate = true
@@ -689,7 +679,7 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 						if (Object.hasOwn(bind_pos, "material")) {
 							// set `envMap` directly on `material` if the instance has `material` prop defined
 							const instance = bind_pos as Mesh
-							const material = instance.material as MaterialWithEnvMap
+							const material = instance.material as MeshMaterialWithEnvMap
 							if (material) {
 								if (Object.hasOwn(material, "envMap")) {
 									material.envMap = camera.renderTarget.texture
@@ -711,7 +701,7 @@ Renders a `CubeMap` which can be used with **non-PBR** materials having an `.env
 				} else if (our_parent) {
 					//`our_parent` is a three.js instance
 					if (Object.hasOwn(our_parent, "material")) {
-						const material = our_parent["material" as keyof typeof our_parent] as MaterialWithEnvMap
+						const material = our_parent["material" as keyof typeof our_parent] as MeshMaterialWithEnvMap
 						if (Object.hasOwn(material, "envMap")) {
 							material.envMap = camera.renderTarget.texture
 						} else {

--- a/src/lib/components/DirectionalLight.svelte
+++ b/src/lib/components/DirectionalLight.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/DirectionalLight.svelte
+++ b/src/lib/components/DirectionalLight.svelte
@@ -962,7 +962,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/DirectionalLight.svelte
+++ b/src/lib/components/DirectionalLight.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _DirectionalLight_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/DirectionalLight.svelte
+++ b/src/lib/components/DirectionalLight.svelte
@@ -3,6 +3,50 @@
 **svelthree** _DirectionalLight_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./DirectionalLight.svelte").default
+
+	type HelperParams = ConstructorParameters<typeof DirectionalLightHelper>
+
+	export interface IStateDirectionalLight {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly light: THREE_DirectionalLight | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_DirectionalLight> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly target: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsDirectionalLight | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly color: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly intensity: number | undefined
+		readonly shadowMapSize: number | undefined
+		readonly shadowBias: number | undefined
+		readonly castShadow: boolean | undefined
+		readonly shadowProps: PropsDirectionalLightShadow | undefined
+		readonly shadowCameraProps: PropsOrthographicCamera | undefined
+		readonly helperParams: RemoveFirst<HelperParams> | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -49,7 +93,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./DirectionalLight.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -450,7 +493,6 @@
 	/** **shorthand** attribute for setting properties of `light.shadow.camera` via an `Object Literal`. */
 	export let shadowCameraProps: PropsOrthographicCamera | undefined = undefined
 
-	type HelperParams = ConstructorParameters<typeof DirectionalLightHelper>
 	export let helperParams: RemoveFirst<HelperParams> | undefined = undefined
 	export let helper: boolean | undefined = undefined
 
@@ -974,6 +1016,55 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateDirectionalLight> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					light,
+					name,
+					params,
+					tabindex,
+					aria,
+					target,
+					mau,
+					matrix,
+					props,
+					pos,
+					lookAt,
+					color,
+					intensity,
+					shadowMapSize,
+					shadowBias,
+					castShadow,
+					shadowProps,
+					shadowCameraProps,
+					helperParams,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Group.svelte
+++ b/src/lib/components/Group.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/Group.svelte
+++ b/src/lib/components/Group.svelte
@@ -3,6 +3,53 @@
 **svelthree** _Group_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./Group.svelte").default
+
+	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
+
+	export interface IStateGroup {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly button: PropButton | undefined
+		readonly link: PropLink | undefined
+		readonly group: THREE_Group | undefined | null
+		readonly name: string | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsGroup | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly boxParams: RemoveFirst<BoxHelperParams> | undefined
+		readonly box: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -43,7 +90,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./Group.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -417,7 +463,6 @@
 		group.userData.root_scene = root_scene
 	}
 
-	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 	export let boxParams: RemoveFirst<BoxHelperParams> | undefined = undefined
 	/** Creates and adds a `BoxHelper`. */
 	export let box: boolean | undefined = undefined
@@ -855,6 +900,51 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateGroup> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					button,
+					link,
+					group,
+					name,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					boxParams,
+					box,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Group.svelte
+++ b/src/lib/components/Group.svelte
@@ -843,7 +843,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/Group.svelte
+++ b/src/lib/components/Group.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _Group_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/HemisphereLight.svelte
+++ b/src/lib/components/HemisphereLight.svelte
@@ -784,7 +784,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/HemisphereLight.svelte
+++ b/src/lib/components/HemisphereLight.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/HemisphereLight.svelte
+++ b/src/lib/components/HemisphereLight.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _HemisphereLight_ Component.
 [ tbd ]  Link to Docs. -->

--- a/src/lib/components/HemisphereLight.svelte
+++ b/src/lib/components/HemisphereLight.svelte
@@ -2,6 +2,43 @@
 @component
 **svelthree** _HemisphereLight_ Component.
 [ tbd ]  Link to Docs. -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./HemisphereLight.svelte").default
+
+	type HelperParams = ConstructorParameters<typeof HemisphereLightHelper>
+
+	export interface IStateHemisphereLight {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly light: THREE_HemisphereLight | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_HemisphereLight> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly props: PropsHemisphereLight | undefined
+		readonly color: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly groundColor: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly intensity: number | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly helperParams: RemoveFirst<HelperParams> | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -38,7 +75,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./HemisphereLight.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -350,7 +386,6 @@
 		}
 	}
 
-	type HelperParams = ConstructorParameters<typeof HemisphereLightHelper>
 	export let helperParams: RemoveFirst<HelperParams> | undefined = undefined
 	export let helper: boolean | undefined = undefined
 
@@ -796,6 +831,48 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateHemisphereLight> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					light,
+					name,
+					params,
+					tabindex,
+					aria,
+					mau,
+					props,
+					color,
+					groundColor,
+					intensity,
+					pos,
+					helperParams,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -673,7 +673,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 			self.$on(type, callback)
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -710,7 +710,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 			}
 
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -728,82 +728,82 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 	export let on_click: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_click !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerup: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerdown: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerdown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerout: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermove: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermove !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermoveover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermoveover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keydown: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keydown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keypress: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keypress !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keyup: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keyup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focus: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focus !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_blur: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_blur !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusin: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusin !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusout: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheel: SvelthreeWheelEventHandler | undefined = undefined // ->  TODO  implement
 	$: if (on_wheel !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheelover: SvelthreeWheelEventHandler | undefined = undefined // -> TODO  implement
 	$: if (on_wheelover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	/** Animation logic to be performed with the (three) object instance created by the component. */

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -3,6 +3,80 @@
 **svelthree** _LoadedGLTF_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./LoadedGLTF.svelte").default
+
+	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
+
+	export interface IStateLoadedGLTF {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly button: PropButton | undefined
+		readonly link: PropLink | undefined
+		readonly container: Object3D | undefined | null
+		readonly name: string | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly add: boolean
+		readonly url: string | undefined
+		readonly draco: string | undefined
+		readonly manager: LoadingManager | undefined
+		readonly content: GLTF | undefined
+		readonly afterLoaded: GLTFAfterLoadedTask[] | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsLoadedGLTF | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly castShadow: boolean | undefined
+		readonly receiveShadow: boolean | undefined
+		readonly boxParams: RemoveFirst<BoxHelperParams> | undefined
+		readonly box: boolean | undefined
+		readonly interact: boolean | undefined | null
+		readonly block: boolean
+		readonly modifiers: SvelthreeModifiersProp | undefined
+		readonly on_click: SvelthreePointerEventHandler | undefined
+		readonly on_pointerup: SvelthreePointerEventHandler | undefined
+		readonly on_pointerdown: SvelthreePointerEventHandler | undefined
+		readonly on_pointerover: SvelthreePointerEventHandler | undefined
+		readonly on_pointerout: SvelthreePointerEventHandler | undefined
+		readonly on_pointermove: SvelthreePointerEventHandler | undefined
+		readonly on_pointermoveover: SvelthreePointerEventHandler | undefined
+		readonly on_keydown: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keypress: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keyup: SvelthreeKeyboardEventHandler | undefined
+		readonly on_focus: SvelthreeFocusEventHandler | undefined
+		readonly on_blur: SvelthreeFocusEventHandler | undefined
+		readonly on_focusin: SvelthreeFocusEventHandler | undefined
+		readonly on_focusout: SvelthreeFocusEventHandler | undefined
+		readonly on_wheel: SvelthreeWheelEventHandler | undefined
+		readonly on_wheelover: SvelthreeWheelEventHandler | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -63,7 +137,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./LoadedGLTF.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -490,7 +563,6 @@
 		container.userData.root_scene = root_scene
 	}
 
-	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 	export let boxParams: RemoveFirst<BoxHelperParams> | undefined = undefined
 	/** Creates and adds a `BoxHelper`. */
 	export let box: boolean | undefined = undefined
@@ -1176,6 +1248,78 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateLoadedGLTF> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					button,
+					link,
+					container,
+					name,
+					tabindex,
+					aria,
+					add,
+					url,
+					draco,
+					manager,
+					content,
+					afterLoaded,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					castShadow,
+					receiveShadow,
+					boxParams,
+					box,
+					interact,
+					block,
+					modifiers,
+					on_click,
+					on_pointerup,
+					on_pointerdown,
+					on_pointerover,
+					on_pointerout,
+					on_pointermove,
+					on_pointermoveover,
+					on_keydown,
+					on_keypress,
+					on_keyup,
+					on_focus,
+					on_blur,
+					on_focusin,
+					on_focusout,
+					on_wheel,
+					on_wheelover,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -1166,7 +1166,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -292,8 +292,6 @@
 	 * />
 	 * ```
 	 * */
-	/*eslint @typescript-eslint/no-explicit-any: ["error", { "ignoreRestArgs": true }]*/
-	//export let afterLoaded: ((content_gltf: GLTF, ...args: any[]) => Promise<void>)[] | undefined = undefined
 	export let afterLoaded: GLTFAfterLoadedTask[] | undefined = undefined
 
 	async function process_afterLoaded() {

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _LoadedGLTF_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/LoadedGLTF.svelte
+++ b/src/lib/components/LoadedGLTF.svelte
@@ -572,13 +572,13 @@
 	export let interact: boolean | undefined | null = undefined
 
 	/**
-	Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
-	* This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
-	* 
-	* Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.  
-	* In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
-	* the object will automatically become an _interaction occluder / blocker_.
-   */
+	 * Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
+	 * This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
+	 *
+	 * Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.
+	 * In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
+	 * the object will automatically become an _interaction occluder / blocker_.
+	 */
 	export let block = false
 
 	const interaction_on_clear: {

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -3,6 +3,78 @@
 **svelthree** _Mesh_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./Mesh.svelte").default<MeshAssignableMaterial>
+
+	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
+
+	export interface IStateMesh {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly button: PropButton | undefined
+		readonly link: PropLink | undefined
+		readonly mesh: THREE_Mesh | undefined | null
+		readonly name: string | undefined
+		readonly material: MeshAssignableMaterial | undefined | null
+		readonly geometry: BufferGeometry | undefined | null
+		readonly params: ConstructorParameters<typeof THREE_Mesh> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly mat: PropMat<MeshAssignableMaterial> | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsMesh | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly castShadow: boolean | undefined
+		readonly receiveShadow: boolean | undefined
+		readonly boxParams: RemoveFirst<BoxHelperParams> | undefined
+		readonly box: boolean | undefined
+		readonly interact: boolean | undefined | null
+		readonly block: boolean
+		readonly modifiers: SvelthreeModifiersProp | undefined
+		readonly on_click: SvelthreePointerEventHandler | undefined
+		readonly on_pointerup: SvelthreePointerEventHandler | undefined
+		readonly on_pointerdown: SvelthreePointerEventHandler | undefined
+		readonly on_pointerover: SvelthreePointerEventHandler | undefined
+		readonly on_pointerout: SvelthreePointerEventHandler | undefined
+		readonly on_pointermove: SvelthreePointerEventHandler | undefined
+		readonly on_pointermoveover: SvelthreePointerEventHandler | undefined
+		readonly on_keydown: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keypress: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keyup: SvelthreeKeyboardEventHandler | undefined
+		readonly on_focus: SvelthreeFocusEventHandler | undefined
+		readonly on_blur: SvelthreeFocusEventHandler | undefined
+		readonly on_focusin: SvelthreeFocusEventHandler | undefined
+		readonly on_focusout: SvelthreeFocusEventHandler | undefined
+		readonly on_wheel: SvelthreeWheelEventHandler | undefined
+		readonly on_wheelover: SvelthreeWheelEventHandler | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -122,7 +194,6 @@
 	export let geometry: BufferGeometry | undefined | null = undefined
 	let geometry_ref: BufferGeometry | undefined = undefined
 
-	type CurrentComponentType = import("./Mesh.svelte").default<AssignedMaterial>
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -618,7 +689,6 @@
 		mesh.userData.root_scene = root_scene
 	}
 
-	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 	export let boxParams: RemoveFirst<BoxHelperParams> | undefined = undefined
 	/** Creates and adds a `BoxHelper`. */
 	export let box: boolean | undefined = undefined
@@ -1295,6 +1365,76 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateMesh> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					button,
+					link,
+					mesh,
+					name,
+					material,
+					geometry,
+					params,
+					tabindex,
+					aria,
+					mau,
+					mat,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					castShadow,
+					receiveShadow,
+					boxParams,
+					box,
+					interact,
+					block,
+					modifiers,
+					on_click,
+					on_pointerup,
+					on_pointerdown,
+					on_pointerover,
+					on_pointerout,
+					on_pointermove,
+					on_pointermoveover,
+					on_keydown,
+					on_keypress,
+					on_keyup,
+					on_focus,
+					on_blur,
+					on_focusin,
+					on_focusout,
+					on_wheel,
+					on_wheelover,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -797,7 +797,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 			self.$on(type, callback)
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -834,7 +834,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 			}
 
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -852,82 +852,82 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 	export let on_click: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_click !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerup: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerdown: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerdown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerout: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermove: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermove !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermoveover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermoveover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keydown: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keydown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keypress: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keypress !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keyup: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keyup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focus: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focus !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_blur: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_blur !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusin: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusin !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusout: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheel: SvelthreeWheelEventHandler | undefined = undefined // ->  TODO  implement
 	$: if (on_wheel !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheelover: SvelthreeWheelEventHandler | undefined = undefined // -> TODO  implement
 	$: if (on_wheelover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	/** Animation logic to be performed with the (three) object instance created by the component. */

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -8,7 +8,7 @@
 
 	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 
-	export interface IStateMesh {
+	export interface IStateMesh<M extends MeshAssignableMaterial> {
 		readonly log_all: boolean
 		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
 		readonly log_rs: boolean
@@ -18,13 +18,13 @@
 		readonly link: PropLink | undefined
 		readonly mesh: THREE_Mesh | undefined | null
 		readonly name: string | undefined
-		readonly material: MeshAssignableMaterial | undefined | null
+		readonly material: M | undefined | null
 		readonly geometry: BufferGeometry | undefined | null
 		readonly params: ConstructorParameters<typeof THREE_Mesh> | undefined
 		readonly tabindex: number | undefined
 		readonly aria: Partial<ARIAMixin> | undefined
 		readonly mau: boolean | undefined
-		readonly mat: PropMat<MeshAssignableMaterial> | undefined
+		readonly mat: PropMat<M> | undefined
 		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
 		readonly props: PropsMesh | undefined
 		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
@@ -1367,7 +1367,7 @@
 		}
 	}
 
-	export const state = (): Partial<IStateMesh> => {
+	export const state = (): Partial<IStateMesh<AssignedMaterial>> => {
 		return {}
 	}
 

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _Mesh_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -696,13 +696,13 @@
 	export let interact: boolean | undefined | null = undefined
 
 	/**
-	Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
-	* This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
-	* 
-	* Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.  
-	* In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
-	* the object will automatically become an _interaction occluder / blocker_.
-   */
+	 * Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
+	 * This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
+	 *
+	 * Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.
+	 * In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
+	 * the object will automatically become an _interaction occluder / blocker_.
+	 */
 	export let block = false
 
 	const interaction_on_clear: {

--- a/src/lib/components/Mesh.svelte
+++ b/src/lib/components/Mesh.svelte
@@ -1283,7 +1283,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/Object3D.svelte
+++ b/src/lib/components/Object3D.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/Object3D.svelte
+++ b/src/lib/components/Object3D.svelte
@@ -3,6 +3,53 @@
 **svelthree** _Object3D_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./Object3D.svelte").default
+
+	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
+
+	export interface IStateObject3D {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly button: PropButton | undefined
+		readonly link: PropLink | undefined
+		readonly object3d: THREE_Object3D | undefined | null
+		readonly name: string | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsObject3D | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly boxParams: RemoveFirst<BoxHelperParams> | undefined
+		readonly box: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -42,7 +89,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./Object3D.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -419,7 +465,6 @@
 		object3d.userData.root_scene = root_scene
 	}
 
-	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 	export let boxParams: RemoveFirst<BoxHelperParams> | undefined = undefined
 	/** Creates and adds a `BoxHelper`. */
 	export let box: boolean | undefined = undefined
@@ -859,6 +904,51 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateObject3D> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					button,
+					link,
+					object3d,
+					name,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					boxParams,
+					box,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Object3D.svelte
+++ b/src/lib/components/Object3D.svelte
@@ -847,7 +847,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/Object3D.svelte
+++ b/src/lib/components/Object3D.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _Object3D_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/OrbitControls.svelte
+++ b/src/lib/components/OrbitControls.svelte
@@ -3,6 +3,40 @@
 **svelthree** _OrbitControls_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./OrbitControls.svelte").default
+
+	export interface IStateOrbitControls {
+		readonly log_all: boolean
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly orbitcontrols: THREE_OrbitControls | undefined | null
+		readonly warn: boolean
+		readonly cam:
+			| PerspectiveCamera
+			| OrthographicCamera
+			| THREE_PerspectiveCamera
+			| THREE_OrthographicCamera
+			| undefined
+		readonly dom_el: HTMLElement | Canvas | undefined
+		readonly props: PropsOrbitControls | undefined
+		readonly enabled: boolean
+		readonly target: Vector3 | undefined
+		readonly rotate: boolean
+		readonly auto: boolean
+		readonly auto_speed: number | undefined
+		readonly damping: boolean
+		readonly pan: boolean
+		readonly zoom: boolean
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import { beforeUpdate, onMount, afterUpdate, onDestroy, getContext } from "svelte"
 	import { get_current_component } from "svelte/internal"
@@ -28,7 +62,6 @@
 	import type { default as OrthographicCamera } from "./OrthographicCamera.svelte"
 	import type { default as Canvas } from "../components/Canvas.svelte"
 
-	type CurrentComponentType = import("./OrbitControls.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -488,4 +521,40 @@
 					}
 			  }
 	)
+
+	export const state = (): Partial<IStateOrbitControls> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_rs,
+					log_lc,
+					orbitcontrols,
+					warn,
+					cam,
+					dom_el,
+					props,
+					enabled,
+					target,
+					rotate,
+					auto,
+					auto_speed,
+					damping,
+					pan,
+					zoom,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
+	}
 </script>

--- a/src/lib/components/OrbitControls.svelte
+++ b/src/lib/components/OrbitControls.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/OrbitControls.svelte
+++ b/src/lib/components/OrbitControls.svelte
@@ -121,7 +121,7 @@
 			}
 
 			// mode 'auto'
-			if (store.rendererComponent?.mode === "auto") {
+			if (store.rendererComponent?.get_mode() === "auto") {
 				if (auto === true) {
 					// schedule render every animation frame
 					rAF.id = requestAnimationFrame(() => on_orbitcontrols_change(null))

--- a/src/lib/components/OrbitControls.svelte
+++ b/src/lib/components/OrbitControls.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _OrbitControls_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/OrthographicCamera.svelte
+++ b/src/lib/components/OrthographicCamera.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/OrthographicCamera.svelte
+++ b/src/lib/components/OrthographicCamera.svelte
@@ -8,6 +8,56 @@ If you use this approach you'll see a warning in the console if you define left,
 - Use `params` attribute to initialize the camera and `props` attribute to set it's properties. 
 - Use `props` attribute only: Camera will be initialized with default constructor values and `props` attribute will set it's properties. 
 [ tbd ]  Link to Docs. -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./OrthographicCamera.svelte").default
+
+	export interface IStateOrthographicCamera {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly id: string | undefined
+		readonly camera: THREE_OrthographicCamera | undefined | null
+		readonly name: string | undefined
+		readonly aspect: boolean | undefined
+		readonly frustumSize: number | undefined
+		readonly params: ConstructorParameters<typeof THREE_OrthographicCamera> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsOrthographicCamera | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly far: number | undefined
+		readonly near: number | undefined
+		readonly view: THREE_OrthographicCamera["view"] | undefined
+		readonly zoom: number | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -50,7 +100,6 @@ If you use this approach you'll see a warning in the console if you define left,
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./OrthographicCamera.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -1050,6 +1099,56 @@ If you use this approach you'll see a warning in the console if you define left,
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateOrthographicCamera> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					id,
+					camera,
+					name,
+					aspect,
+					frustumSize,
+					params,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					far,
+					near,
+					view,
+					zoom,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/OrthographicCamera.svelte
+++ b/src/lib/components/OrthographicCamera.svelte
@@ -1038,7 +1038,7 @@ If you use this approach you'll see a warning in the console if you define left,
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/OrthographicCamera.svelte
+++ b/src/lib/components/OrthographicCamera.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _OrthographicCamera_ Component.
 

--- a/src/lib/components/PerspectiveCamera.svelte
+++ b/src/lib/components/PerspectiveCamera.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _PerspectiveCamera_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/PerspectiveCamera.svelte
+++ b/src/lib/components/PerspectiveCamera.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/PerspectiveCamera.svelte
+++ b/src/lib/components/PerspectiveCamera.svelte
@@ -1114,7 +1114,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/PerspectiveCamera.svelte
+++ b/src/lib/components/PerspectiveCamera.svelte
@@ -3,6 +3,59 @@
 **svelthree** _PerspectiveCamera_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./PerspectiveCamera.svelte").default
+
+	export interface IStatePerspectiveCamera {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly id: string | undefined
+		readonly camera: THREE_PerspectiveCamera | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_PerspectiveCamera> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsPerspectiveCamera | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly aspect: number | boolean | undefined
+		readonly far: number | undefined
+		readonly filmGauge: number | undefined
+		readonly filmOffset: number | undefined
+		readonly focus: number | undefined
+		readonly fov: number | undefined
+		readonly near: number | undefined
+		readonly view: THREE_PerspectiveCamera["view"] | undefined
+		readonly zoom: number | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -43,7 +96,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./PerspectiveCamera.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -1126,6 +1178,59 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStatePerspectiveCamera> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					id,
+					camera,
+					name,
+					params,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					aspect,
+					far,
+					filmGauge,
+					filmOffset,
+					focus,
+					fov,
+					near,
+					view,
+					zoom,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/PointLight.svelte
+++ b/src/lib/components/PointLight.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _PointLight_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/PointLight.svelte
+++ b/src/lib/components/PointLight.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/PointLight.svelte
+++ b/src/lib/components/PointLight.svelte
@@ -878,7 +878,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/PointLight.svelte
+++ b/src/lib/components/PointLight.svelte
@@ -3,6 +3,59 @@
 **svelthree** _PointLight_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./PointLight.svelte").default
+
+	type HelperParams = ConstructorParameters<typeof PointLightHelper>
+
+	export interface IStatePointLight {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly light: THREE_PointLight | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_PointLight> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsPointLight | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly color: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly intensity: number | undefined
+		readonly shadowMapSize: number | undefined
+		readonly shadowBias: number | undefined
+		readonly castShadow: boolean | undefined
+		readonly shadowProps: PropsPointLightShadow | undefined
+		readonly shadowCameraProps: PropsPerspectiveCamera | undefined
+		readonly helperParams: RemoveFirst<HelperParams> | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -44,7 +97,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./PointLight.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -444,7 +496,6 @@
 	/** **shorthand** attribute for setting properties of `light.shadow.camera` via an `Object Literal`. */
 	export let shadowCameraProps: PropsPerspectiveCamera | undefined = undefined
 
-	type HelperParams = ConstructorParameters<typeof PointLightHelper>
 	export let helperParams: RemoveFirst<HelperParams> | undefined = undefined
 	export let helper: boolean | undefined = undefined
 
@@ -890,6 +941,57 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStatePointLight> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					light,
+					name,
+					params,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					color,
+					intensity,
+					shadowMapSize,
+					shadowBias,
+					castShadow,
+					shadowProps,
+					shadowCameraProps,
+					helperParams,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -8,7 +8,7 @@
 
 	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 
-	export interface IStatePoints {
+	export interface IStatePoints<M extends PointsAssignableMaterial> {
 		readonly log_all: boolean
 		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
 		readonly log_rs: boolean
@@ -18,13 +18,13 @@
 		readonly link: PropLink | undefined
 		readonly points: THREE_Points | undefined | null
 		readonly name: string | undefined
-		readonly material: PointsAssignableMaterial | undefined | null
+		readonly material: M | undefined | null
 		readonly geometry: BufferGeometry | undefined | null
 		readonly params: ConstructorParameters<typeof THREE_Points> | undefined
 		readonly tabindex: number | undefined
 		readonly aria: Partial<ARIAMixin> | undefined
 		readonly mau: boolean | undefined
-		readonly mat: PropMat<PointsAssignableMaterial> | undefined
+		readonly mat: PropMat<M> | undefined
 		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
 		readonly props: PropsPoints | undefined
 		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
@@ -1369,7 +1369,7 @@
 		}
 	}
 
-	export const state = (): Partial<IStatePoints> => {
+	export const state = (): Partial<IStatePoints<AssignedMaterial>> => {
 		return {}
 	}
 

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -3,6 +3,78 @@
 **svelthree** _Points_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./Points.svelte").default<PointsAssignableMaterial>
+
+	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
+
+	export interface IStatePoints {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly button: PropButton | undefined
+		readonly link: PropLink | undefined
+		readonly points: THREE_Points | undefined | null
+		readonly name: string | undefined
+		readonly material: PointsAssignableMaterial | undefined | null
+		readonly geometry: BufferGeometry | undefined | null
+		readonly params: ConstructorParameters<typeof THREE_Points> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly mat: PropMat<PointsAssignableMaterial> | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsPoints | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly castShadow: boolean | undefined
+		readonly receiveShadow: boolean | undefined
+		readonly boxParams: RemoveFirst<BoxHelperParams> | undefined
+		readonly box: boolean | undefined
+		readonly interact: boolean | undefined | null
+		readonly block: boolean
+		readonly modifiers: SvelthreeModifiersProp | undefined
+		readonly on_click: SvelthreePointerEventHandler | undefined
+		readonly on_pointerup: SvelthreePointerEventHandler | undefined
+		readonly on_pointerdown: SvelthreePointerEventHandler | undefined
+		readonly on_pointerover: SvelthreePointerEventHandler | undefined
+		readonly on_pointerout: SvelthreePointerEventHandler | undefined
+		readonly on_pointermove: SvelthreePointerEventHandler | undefined
+		readonly on_pointermoveover: SvelthreePointerEventHandler | undefined
+		readonly on_keydown: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keypress: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keyup: SvelthreeKeyboardEventHandler | undefined
+		readonly on_focus: SvelthreeFocusEventHandler | undefined
+		readonly on_blur: SvelthreeFocusEventHandler | undefined
+		readonly on_focusin: SvelthreeFocusEventHandler | undefined
+		readonly on_focusout: SvelthreeFocusEventHandler | undefined
+		readonly on_wheel: SvelthreeWheelEventHandler | undefined
+		readonly on_wheelover: SvelthreeWheelEventHandler | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -122,7 +194,6 @@
 	export let geometry: BufferGeometry | undefined | null = undefined
 	let geometry_ref: BufferGeometry | undefined = undefined
 
-	type CurrentComponentType = import("./Points.svelte").default<AssignedMaterial>
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -620,7 +691,6 @@
 		points.userData.root_scene = root_scene
 	}
 
-	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 	export let boxParams: RemoveFirst<BoxHelperParams> | undefined = undefined
 	/** Creates and adds a `BoxHelper`. */
 	export let box: boolean | undefined = undefined
@@ -1297,6 +1367,76 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStatePoints> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					button,
+					link,
+					points,
+					name,
+					material,
+					geometry,
+					params,
+					tabindex,
+					aria,
+					mau,
+					mat,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					castShadow,
+					receiveShadow,
+					boxParams,
+					box,
+					interact,
+					block,
+					modifiers,
+					on_click,
+					on_pointerup,
+					on_pointerdown,
+					on_pointerover,
+					on_pointerout,
+					on_pointermove,
+					on_pointermoveover,
+					on_keydown,
+					on_keypress,
+					on_keyup,
+					on_focus,
+					on_blur,
+					on_focusin,
+					on_focusout,
+					on_wheel,
+					on_wheelover,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -1285,7 +1285,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _Points_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -698,13 +698,13 @@
 	export let interact: boolean | undefined | null = undefined
 
 	/**
-	Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
-	* This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
-	* 
-	* Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.  
-	* In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
-	* the object will automatically become an _interaction occluder / blocker_.
-   */
+	 * Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
+	 * This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
+	 *
+	 * Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.
+	 * In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
+	 * the object will automatically become an _interaction occluder / blocker_.
+	 */
 	export let block = false
 
 	const interaction_on_clear: {

--- a/src/lib/components/Points.svelte
+++ b/src/lib/components/Points.svelte
@@ -799,7 +799,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 			self.$on(type, callback)
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -836,7 +836,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 			}
 
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -854,82 +854,82 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 	export let on_click: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_click !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerup: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerdown: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerdown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerout: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermove: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermove !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermoveover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermoveover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keydown: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keydown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keypress: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keypress !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keyup: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keyup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focus: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focus !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_blur: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_blur !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusin: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusin !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusout: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheel: SvelthreeWheelEventHandler | undefined = undefined // ->  TODO  implement
 	$: if (on_wheel !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheelover: SvelthreeWheelEventHandler | undefined = undefined // -> TODO  implement
 	$: if (on_wheelover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	/** Animation logic to be performed with the (three) object instance created by the component. */

--- a/src/lib/components/RectAreaLight.svelte
+++ b/src/lib/components/RectAreaLight.svelte
@@ -919,7 +919,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/RectAreaLight.svelte
+++ b/src/lib/components/RectAreaLight.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/RectAreaLight.svelte
+++ b/src/lib/components/RectAreaLight.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _RectAreaLight_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/RectAreaLight.svelte
+++ b/src/lib/components/RectAreaLight.svelte
@@ -3,6 +3,57 @@
 **svelthree** _RectAreaLight_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./RectAreaLight.svelte").default
+
+	type HelperParams = ConstructorParameters<typeof RectAreaLightHelper>
+
+	export interface IStateRectAreaLight {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly light: THREE_RectAreaLight | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_RectAreaLight> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsRectAreaLight | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly height: number | undefined
+		readonly width: number | undefined
+		readonly color: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly intensity: number | undefined
+		readonly power: number | undefined
+		readonly helperParams: RemoveFirst<HelperParams> | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -43,7 +94,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./RectAreaLight.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -485,7 +535,6 @@
 		}
 	}
 
-	type HelperParams = ConstructorParameters<typeof RectAreaLightHelper>
 	export let helperParams: RemoveFirst<HelperParams> | undefined = undefined
 	export let helper: boolean | undefined = undefined
 
@@ -931,6 +980,55 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateRectAreaLight> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					light,
+					name,
+					params,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					height,
+					width,
+					color,
+					intensity,
+					power,
+					helperParams,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -3,6 +3,80 @@
 **svelthree** _Scene_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./Scene.svelte").default
+
+	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
+
+	export interface IStateScene {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly id: string | undefined
+		readonly button: PropButton | undefined
+		readonly link: PropLink | undefined
+		readonly scene: THREE_Scene | undefined | null
+		readonly name: string | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsScene | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly rot:
+			| Euler
+			| Parameters<Euler["set"]>
+			| Quaternion
+			| Parameters<Quaternion["set"]>
+			| Vector3
+			| Parameters<Vector3["set"]>
+			| undefined
+		readonly quat: Quaternion | Parameters<Quaternion["set"]> | undefined
+		readonly scale: Vector3 | Parameters<Vector3["set"]> | number | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly castShadow: boolean | undefined
+		readonly receiveShadow: boolean | undefined
+		readonly bg: Texture | Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly bg_tex: { url: string; mapping?: Mapping } | undefined
+		readonly fog: FogBase | undefined
+		readonly env: Texture | undefined
+		readonly env_tex: { url: string; mapping?: Mapping } | undefined
+		readonly boxParams: RemoveFirst<BoxHelperParams> | undefined
+		readonly box: boolean | undefined
+		readonly interact: boolean | undefined | null
+		readonly block: boolean
+		readonly modifiers: SvelthreeModifiersProp | undefined
+		readonly on_click: SvelthreePointerEventHandler | undefined
+		readonly on_pointerup: SvelthreePointerEventHandler | undefined
+		readonly on_pointerdown: SvelthreePointerEventHandler | undefined
+		readonly on_pointerover: SvelthreePointerEventHandler | undefined
+		readonly on_pointerout: SvelthreePointerEventHandler | undefined
+		readonly on_pointermove: SvelthreePointerEventHandler | undefined
+		readonly on_pointermoveover: SvelthreePointerEventHandler | undefined
+		readonly on_keydown: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keypress: SvelthreeKeyboardEventHandler | undefined
+		readonly on_keyup: SvelthreeKeyboardEventHandler | undefined
+		readonly on_focus: SvelthreeFocusEventHandler | undefined
+		readonly on_blur: SvelthreeFocusEventHandler | undefined
+		readonly on_focusin: SvelthreeFocusEventHandler | undefined
+		readonly on_focusout: SvelthreeFocusEventHandler | undefined
+		readonly on_wheel: SvelthreeWheelEventHandler | undefined
+		readonly on_wheelover: SvelthreeWheelEventHandler | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import { beforeUpdate, onMount, afterUpdate, onDestroy, getContext, setContext, tick } from "svelte"
 	import { get_current_component } from "svelte/internal"
@@ -58,7 +132,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./Scene.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -715,7 +788,6 @@
 		}
 	}
 
-	type BoxHelperParams = ConstructorParameters<typeof BoxHelper>
 	export let boxParams: RemoveFirst<BoxHelperParams> | undefined = undefined
 	/** Creates and adds a `BoxHelper`. */
 	export let box: boolean | undefined = undefined
@@ -1404,6 +1476,78 @@
 				store.rendererComponent.schedule_render_auto(scene)
 			}
 		}
+	}
+
+	export const state = (): Partial<IStateScene> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					id,
+					button,
+					link,
+					scene,
+					name,
+					tabindex,
+					aria,
+					mau,
+					matrix,
+					props,
+					pos,
+					rot,
+					quat,
+					scale,
+					lookAt,
+					castShadow,
+					receiveShadow,
+					bg,
+					bg_tex,
+					fog,
+					env,
+					env_tex,
+					boxParams,
+					box,
+					interact,
+					block,
+					modifiers,
+					on_click,
+					on_pointerup,
+					on_pointerdown,
+					on_pointerover,
+					on_pointerout,
+					on_pointermove,
+					on_pointermoveover,
+					on_keydown,
+					on_keypress,
+					on_keyup,
+					on_focus,
+					on_blur,
+					on_focusin,
+					on_focusout,
+					on_wheel,
+					on_wheelover,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -1377,7 +1377,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			if (root_scene) {
 				// we're not the root scene (root_scene is not `null`)
 				// prevent an additional component update by not accessing the `root_scene` prop directly.

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -366,12 +366,18 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 		if (scene) {
 			// IMPORTANT  lets the renderer perform scene.updateMatrixWorld() on every render pass.
+			// THREE  TS: no `autoUpdate` in type `THREE.Scene`
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
 			scene.autoUpdate = true
 
 			// IMPORTANT  `scene.updateMatrixWorld()` will always call `matrixUpdate()` first which will set `scene.matrixWorldNeedsUpdate` to `true`.
 			scene.matrixAutoUpdate = true
 
 			if (verbose && log_mau) {
+				// THREE  TS: no `autoUpdate` in type `THREE.Scene`
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
 				console.debug(...c_mau(c_name, "enable_scene_auto! scene.autoUpdate:", scene.autoUpdate))
 			}
 			if (verbose && log_mau) {
@@ -387,6 +393,9 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 		if (scene) {
 			// IMPORTANT  lets the renderer perform scene.updateMatrixWorld() on every render pass -> we don't have to do it in the component!.
+			// THREE  TS: no `autoUpdate` in type `THREE.Scene`
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
 			scene.autoUpdate = true
 
 			// IMPORTANT  prevents calling `matrixUpdate()` on `scene.updateMatrixWorld()`
@@ -396,6 +405,9 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 			scene.matrixAutoUpdate = false
 
 			if (verbose && log_mau) {
+				// THREE  TS: no `autoUpdate` in type `THREE.Scene`
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
 				console.debug(...c_mau(c_name, "disable_scene_auto! scene.autoUpdate:", scene.autoUpdate))
 			}
 			if (verbose && log_mau) {
@@ -882,7 +894,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 			self.$on(type, callback)
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -919,7 +931,7 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 			}
 
 			if (interaction_comp) {
-				interaction_comp.update_listeners = true
+				interaction_comp.$set({ update_listeners: true })
 			} else {
 				console.error("SVELTHREE > Mesh > on : Couldn't update listeners, 'interaction_comp' not available!", {
 					interaction_comp
@@ -937,82 +949,82 @@ svelthree uses svelte-accmod, where accessors are always `true`, regardless of `
 
 	export let on_click: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_click !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerup: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerdown: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerdown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointerout: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointerout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermove: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermove !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_pointermoveover: SvelthreePointerEventHandler | undefined = undefined
 	$: if (on_pointermoveover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keydown: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keydown !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keypress: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keypress !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_keyup: SvelthreeKeyboardEventHandler | undefined = undefined
 	$: if (on_keyup !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focus: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focus !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_blur: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_blur !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusin: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusin !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_focusout: SvelthreeFocusEventHandler | undefined = undefined
 	$: if (on_focusout !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheel: SvelthreeWheelEventHandler | undefined = undefined // ->  TODO  implement
 	$: if (on_wheel !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	export let on_wheelover: SvelthreeWheelEventHandler | undefined = undefined // -> TODO  implement
 	$: if (on_wheelover !== undefined && interaction_comp && shadow_dom_el) {
-		interaction_comp.update_listeners = true
+		interaction_comp.$set({ update_listeners: true })
 	}
 
 	/** Animation logic to be performed with the (three) object instance created by the component. */

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _Scene_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -793,13 +793,13 @@
 	export let interact: boolean | undefined | null = undefined
 
 	/**
-	Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
-	* This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
-	* 
-	* Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.  
-	* In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
-	* the object will automatically become an _interaction occluder / blocker_.
-   */
+	 * Adds component's three.js object instance to the `raycast` array even if it's not set to `interact` ( _no interaction listeners_ ).
+	 * This way the object acts as a pure _interaction occluder / blocker_ -> will be detected / intersected by `Raycaster`'s ray.
+	 *
+	 * Setting the `block` prop makes sense only if the `interact` prop is not set / set to `false`.
+	 * In case `interact` prop is set / set to `true`, but no e.g. `on:<event_name>` directives or `on_<event_name>` internal actions are set,
+	 * the object will automatically become an _interaction occluder / blocker_.
+	 */
 	export let block = false
 
 	const interaction_on_clear: {

--- a/src/lib/components/SpotLight.svelte
+++ b/src/lib/components/SpotLight.svelte
@@ -2,7 +2,7 @@
 `accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
 svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
 -->
-<svelte:options accessors />
+<svelte:options accessors={false} />
 
 <!--
 @component

--- a/src/lib/components/SpotLight.svelte
+++ b/src/lib/components/SpotLight.svelte
@@ -1038,7 +1038,7 @@
 	)
 
 	const schedule_render_auto = (): void => {
-		if (store?.rendererComponent?.mode === "auto") {
+		if (store?.rendererComponent?.get_mode() === "auto") {
 			// prevent an additional component update by not accessing the `root_scene` prop directly.
 			if (root_scene_obj.value) {
 				root_scene_obj.value.userData.dirty = true

--- a/src/lib/components/SpotLight.svelte
+++ b/src/lib/components/SpotLight.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors={false} />
-
-<!--
 @component
 **svelthree** _SpotLight_ Component.
 [ tbd ]  Link to Docs.

--- a/src/lib/components/SpotLight.svelte
+++ b/src/lib/components/SpotLight.svelte
@@ -3,6 +3,55 @@
 **svelthree** _SpotLight_ Component.
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./SpotLight.svelte").default
+
+	type HelperParams = ConstructorParameters<typeof SpotLightHelper>
+
+	export interface IStateSpotLight {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly log_mau: boolean
+		readonly light: THREE_SpotLight | undefined | null
+		readonly name: string | undefined
+		readonly params: ConstructorParameters<typeof THREE_SpotLight> | undefined
+		readonly tabindex: number | undefined
+		readonly aria: Partial<ARIAMixin> | undefined
+		readonly target: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly mau: boolean | undefined
+		readonly matrix: Matrix4 | Parameters<Matrix4["set"]> | undefined
+		readonly props: PropsSpotLight | undefined
+		readonly pos: Vector3 | Parameters<Vector3["set"]> | undefined
+		readonly lookAt: Vector3 | Parameters<Vector3["set"]> | Targetable | undefined | null
+		readonly angle: number | undefined
+		readonly decay: number | undefined
+		readonly distance: number | undefined
+		readonly penumbra: number | undefined
+		readonly power: number | undefined
+		readonly color: Color | string | number | [r: number, g: number, b: number] | Vector3 | undefined
+		readonly intensity: number | undefined
+		readonly shadowMapSize: number | undefined
+		readonly shadowBias: number | undefined
+		readonly castShadow: boolean | undefined
+		readonly shadowProps: PropsSpotLightShadow | undefined
+		readonly shadowCameraProps: PropsPerspectiveCamera | undefined
+		readonly helperParams: RemoveFirst<HelperParams> | undefined
+		readonly helper: boolean | undefined
+		readonly animation: SvelthreeAnimationFunction | undefined
+		readonly aniauto: boolean | undefined
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import type { Scene } from "three"
 
@@ -45,7 +94,6 @@
 	 */
 	import { browser } from "$app/environment"
 
-	type CurrentComponentType = import("./SpotLight.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -526,7 +574,6 @@
 	/** **shorthand** attribute for setting properties of `light.shadow.camera` via an `Object Literal`. */
 	export let shadowCameraProps: PropsPerspectiveCamera | undefined = undefined
 
-	type HelperParams = ConstructorParameters<typeof SpotLightHelper>
 	export let helperParams: RemoveFirst<HelperParams> | undefined = undefined
 	export let helper: boolean | undefined = undefined
 
@@ -1050,6 +1097,60 @@
 			}
 			store.rendererComponent.schedule_render_auto(root_scene)
 		}
+	}
+
+	export const state = (): Partial<IStateSpotLight> => {
+		return {}
+	}
+
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					log_mau,
+					light,
+					name,
+					params,
+					tabindex,
+					aria,
+					target,
+					mau,
+					matrix,
+					props,
+					pos,
+					lookAt,
+					angle,
+					decay,
+					distance,
+					penumbra,
+					power,
+					color,
+					intensity,
+					shadowMapSize,
+					shadowBias,
+					castShadow,
+					shadowProps,
+					shadowCameraProps,
+					helperParams,
+					helper,
+					animation,
+					aniauto,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateStart,
+					afterUpdateEnd,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
 	}
 </script>
 

--- a/src/lib/components/WebGLRenderer.svelte
+++ b/src/lib/components/WebGLRenderer.svelte
@@ -3,6 +3,47 @@
 This is a **svelthree** _WebGLRenderer_ Component.  
 [ tbd ]  Link to Docs.
 -->
+<script context="module" lang="ts">
+	type CurrentComponentType = import("./WebGLRenderer.svelte").default
+
+	interface WebGLRendererInput {
+		canvas: Canvas
+		scene_id: string
+		cam_id: string
+	}
+
+	interface WebGLRendererOutput {
+		canvas: HTMLCanvasElement | HTMLElement
+	}
+
+	interface WebGLRendererOutputsQueueItem {
+		dom_element: HTMLCanvasElement
+		viewOffset?: number[]
+	}
+
+	export interface IStateWebGLRenderer {
+		readonly log_all: boolean
+		readonly log_dev: { [P in keyof LogDEV]: LogDEV[P] } | undefined
+		readonly log_rs: boolean
+		readonly log_lc: { [P in keyof LogLC]: LogLC[P] } | undefined
+		readonly inputs: WebGLRendererInput[] | undefined
+		readonly outputs: WebGLRendererOutput[] | undefined
+		readonly params: { [P in keyof WebGLRendererParameters]: WebGLRendererParameters[P] } | undefined
+		readonly props: { [P in keyof PropsWebGLRenderer]: PropsWebGLRenderer[P] } | undefined
+		readonly shadowmap: boolean
+		readonly shadowmap_type: ShadowMapType
+		readonly xr: boolean | undefined
+		readonly mode: WebGLRendererMode
+		readonly enabled: boolean
+		readonly onMountReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyStart: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyEnd: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly onDestroyReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly beforeUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+		readonly afterUpdateReplace: SvelthreeLifecycleCallback<CurrentComponentType> | undefined
+	}
+</script>
+
 <script lang="ts">
 	import { afterUpdate, beforeUpdate, onDestroy, createEventDispatcher, onMount, tick, getContext } from "svelte"
 	import { get_current_component } from "svelte/internal"
@@ -26,7 +67,6 @@ This is a **svelthree** _WebGLRenderer_ Component.
 	} from "../types/types-extra"
 	import type { PropsWebGLRenderer } from "../types/types-comp-props"
 
-	type CurrentComponentType = import("./WebGLRenderer.svelte").default
 	const self = get_current_component()
 	const c_name = get_comp_name(self)
 	/** svelthree component's type (e.g. `type` prop value of component `Foo` will be `'Foo'`) */
@@ -81,12 +121,6 @@ This is a **svelthree** _WebGLRenderer_ Component.
 	 */
 	let inside: boolean | undefined = undefined
 	$: inside = !!sti
-
-	interface WebGLRendererInput {
-		canvas: Canvas
-		scene_id: string
-		cam_id: string
-	}
 
 	/**
 	 * An array of configuration objects specifying `Canvas` components incl. `Scene` and `Camera` components' `id`s that should be rendered.
@@ -151,15 +185,6 @@ This is a **svelthree** _WebGLRenderer_ Component.
 
 			inputs_processed = true
 		}
-	}
-
-	interface WebGLRendererOutput {
-		canvas: HTMLCanvasElement | HTMLElement
-	}
-
-	interface WebGLRendererOutputsQueueItem {
-		dom_element: HTMLCanvasElement
-		viewOffset?: number[]
 	}
 
 	/** An array of `Canvas` components or `<canvas>` DOM elements to rendered to. */
@@ -796,7 +821,7 @@ This is a **svelthree** _WebGLRenderer_ Component.
 					if (store.cubeCameras.length) {
 						for (let i = 0; i < store.cubeCameras.length; i++) {
 							const cubecam: CubeCamera = store.cubeCameras[i]
-							const cubecam_state = cubecam.$capture_state() as unknown as { [key: string]: unknown }
+							const cubecam_state = cubecam.state()
 							if (cubecam_state.dynamic) {
 								cubecam.update_cubecam()
 							}
@@ -815,7 +840,7 @@ This is a **svelthree** _WebGLRenderer_ Component.
 				if (store.cubeCameras.length) {
 					for (let i = 0; i < store.cubeCameras.length; i++) {
 						const cubecam: CubeCamera = store.cubeCameras[i]
-						const cubecam_state = cubecam.$capture_state() as unknown as { [key: string]: unknown }
+						const cubecam_state = cubecam.state()
 						if (cubecam_state.dynamic) {
 							cubecam.update_cubecam()
 						}
@@ -1136,4 +1161,35 @@ This is a **svelthree** _WebGLRenderer_ Component.
 					}
 			  }
 	)
+	export const state = (): Partial<IStateWebGLRenderer> => {
+		return {}
+	}
+	if (!Object.hasOwn(self, "state")) {
+		Object.defineProperty(self, "state", {
+			value: () => {
+				return {
+					log_all,
+					log_dev,
+					log_rs,
+					log_lc,
+					inputs,
+					outputs,
+					params,
+					props,
+					shadowmap,
+					shadowmap_type,
+					xr,
+					mode,
+					enabled,
+					onMountReplace,
+					onDestroyStart,
+					onDestroyEnd,
+					onDestroyReplace,
+					beforeUpdateReplace,
+					afterUpdateReplace
+				}
+			},
+			writable: false
+		})
+	}
 </script>

--- a/src/lib/components/WebGLRenderer.svelte
+++ b/src/lib/components/WebGLRenderer.svelte
@@ -989,6 +989,11 @@ This is a **svelthree** _WebGLRenderer_ Component.
 		}
 	}
 
+	/** Returns current renderer mode: `"auto"` or `"always"`. */
+	export const get_mode = (): WebGLRendererMode => {
+		return mode
+	}
+
 	/** Returns the **three.js instance** of the renderer. */
 	export const get_renderer = (): WebGLRenderer => {
 		return renderer

--- a/src/lib/components/WebGLRenderer.svelte
+++ b/src/lib/components/WebGLRenderer.svelte
@@ -796,7 +796,8 @@ This is a **svelthree** _WebGLRenderer_ Component.
 					if (store.cubeCameras.length) {
 						for (let i = 0; i < store.cubeCameras.length; i++) {
 							const cubecam: CubeCamera = store.cubeCameras[i]
-							if (cubecam.dynamic) {
+							const cubecam_state = cubecam.$capture_state() as unknown as { [key: string]: unknown }
+							if (cubecam_state.dynamic) {
 								cubecam.update_cubecam()
 							}
 						}
@@ -814,7 +815,8 @@ This is a **svelthree** _WebGLRenderer_ Component.
 				if (store.cubeCameras.length) {
 					for (let i = 0; i < store.cubeCameras.length; i++) {
 						const cubecam: CubeCamera = store.cubeCameras[i]
-						if (cubecam.dynamic) {
+						const cubecam_state = cubecam.$capture_state() as unknown as { [key: string]: unknown }
+						if (cubecam_state.dynamic) {
 							cubecam.update_cubecam()
 						}
 					}

--- a/src/lib/components/WebGLRenderer.svelte
+++ b/src/lib/components/WebGLRenderer.svelte
@@ -1,10 +1,4 @@
 <!--
-`accessors:true` hast to be set per component because of the svelte-language-server bug, otherwise accessors would be falsely detected as missing and highlighted as errors.
-svelthree uses svelte-accmod, where accessors are always `true`, regardless of `svelte:options`.  
--->
-<svelte:options accessors />
-
-<!-- 
 @component
 This is a **svelthree** _WebGLRenderer_ Component.  
 [ tbd ]  Link to Docs.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -64,6 +64,7 @@ export type { PropLink, PropButton, PropWebGLRenderTargetOptions } from "./types
 
 // misc
 export type {
+	AnySvelthreeComponent,
 	Targetable,
 	TargetableSvelthreeComponent,
 	SvelthreeLifecycleCallback,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -30,6 +30,9 @@ export type {
 	MeshMaterialWithEnvMap
 } from "./types/types-extra"
 
+// Interaction related
+export type { SvelthreeInteractableComponent, SvelthreeInteractionEvent } from "./types/types-extra"
+
 // `props` Object Literal types
 export type {
 	PropsObject3D,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -22,6 +22,14 @@ export { default as CubeCamera } from "./components/CubeCamera.svelte"
 export type { prop } from "./types/types-extra"
 export type { PropMat } from "./types/types-comp-props"
 
+// Material related
+export type {
+	MeshAssignableMaterial,
+	PointsAssignableMaterial,
+	MeshMaterialWithColor,
+	MeshMaterialWithEnvMap
+} from "./types/types-extra"
+
 // `props` Object Literal types
 export type {
 	PropsObject3D,

--- a/src/lib/logic/shared/remove.ts
+++ b/src/lib/logic/shared/remove.ts
@@ -34,7 +34,9 @@ const clear_new_instance_managing_component = (
 	const managed_by_component: AnySvelthreeComponent | null =
 		(new_instance?.userData?.svelthreeComponent as AnySvelthreeComponent) || null
 	const same_component = managed_by_component === current_component
-	const same_instance = managed_by_component?.[instance_name as keyof AnySvelthreeComponent] === new_instance
+	const component_state = managed_by_component?.$capture_state() as unknown as { [key: string]: unknown }
+	const instance = component_state?.[instance_name]
+	const same_instance = instance === new_instance
 
 	if (managed_by_component && !same_component && same_instance) {
 		//console.warn('clear current managing component!')

--- a/src/lib/logic/shared/remove.ts
+++ b/src/lib/logic/shared/remove.ts
@@ -34,8 +34,8 @@ const clear_new_instance_managing_component = (
 	const managed_by_component: AnySvelthreeComponent | null =
 		(new_instance?.userData?.svelthreeComponent as AnySvelthreeComponent) || null
 	const same_component = managed_by_component === current_component
-	const component_state = managed_by_component?.$capture_state() as unknown as { [key: string]: unknown }
-	const instance = component_state?.[instance_name]
+	const component_state = managed_by_component?.state()
+	const instance = component_state?.[instance_name as keyof typeof component_state]
 	const same_instance = instance === new_instance
 
 	if (managed_by_component && !same_component && same_instance) {

--- a/src/lib/types/types-extra.ts
+++ b/src/lib/types/types-extra.ts
@@ -48,8 +48,22 @@ export type get_props<T> = OnlyWritableNonFunctionProps<T>
 export type RemoveFirst<T extends unknown[]> = T extends [unknown, ...infer R] ? R : T
 export type RemoveLast<T extends unknown[]> = T extends [...infer H, unknown] ? H : T
 
-export type MeshAssignableMaterial = THREE.Material | THREE.Material[]
-export type PointsAssignableMaterial = THREE.Material | THREE.Material[] | THREE.PointsMaterial
+export type MeshAssignableMaterial =
+	| THREE.MeshBasicMaterial
+	| THREE.MeshDepthMaterial
+	| THREE.MeshDistanceMaterial
+	| THREE.MeshLambertMaterial
+	| THREE.MeshMatcapMaterial
+	| THREE.MeshNormalMaterial
+	| THREE.MeshPhongMaterial
+	| THREE.MeshPhysicalMaterial
+	| THREE.MeshStandardMaterial
+	| THREE.MeshToonMaterial
+	| THREE.RawShaderMaterial
+	| THREE.ShaderMaterial
+	| THREE.ShadowMaterial
+
+export type PointsAssignableMaterial = THREE.PointsMaterial | MeshAssignableMaterial
 
 // Animation
 

--- a/src/lib/types/types-extra.ts
+++ b/src/lib/types/types-extra.ts
@@ -48,6 +48,36 @@ export type get_props<T> = OnlyWritableNonFunctionProps<T>
 export type RemoveFirst<T extends unknown[]> = T extends [unknown, ...infer R] ? R : T
 export type RemoveLast<T extends unknown[]> = T extends [...infer H, unknown] ? H : T
 
+export type MeshMaterialWithColor =
+	| THREE.MeshBasicMaterial
+	//| THREE.MeshDepthMaterial
+	//| THREE.MeshDistanceMaterial
+	| THREE.MeshLambertMaterial
+	| THREE.MeshMatcapMaterial
+	//| THREE.MeshNormalMaterial
+	| THREE.MeshPhongMaterial
+	| THREE.MeshPhysicalMaterial
+	| THREE.MeshStandardMaterial
+	| THREE.MeshToonMaterial
+	//| THREE.RawShaderMaterial
+	//| THREE.ShaderMaterial
+	| THREE.ShadowMaterial
+
+export type MeshMaterialWithEnvMap =
+	| THREE.MeshBasicMaterial
+	//| THREE.MeshDepthMaterial
+	//| THREE.MeshDistanceMaterial
+	| THREE.MeshLambertMaterial
+	//| THREE.MeshMatcapMaterial
+	//| THREE.MeshNormalMaterial
+	| THREE.MeshPhongMaterial
+	| THREE.MeshPhysicalMaterial
+	| THREE.MeshStandardMaterial
+//| THREE.MeshToonMaterial
+//| THREE.RawShaderMaterial
+//| THREE.ShaderMaterial
+//| THREE.ShadowMaterial
+
 export type MeshAssignableMaterial =
 	| THREE.MeshBasicMaterial
 	| THREE.MeshDepthMaterial

--- a/src/lib/utils/SvelthreeGLTF.ts
+++ b/src/lib/utils/SvelthreeGLTF.ts
@@ -190,11 +190,11 @@ export default class SvelthreeGLTF {
 			const comp = item.svelthree_comp
 
 			if (comp) {
-				comp.scale = new Vector3().copy(item.obj.scale)
-				comp.pos = new Vector3().copy(item.obj.position)
-				comp.rot = new Euler().copy(item.obj.rotation)
-				comp.castShadow = item.obj.castShadow
-				comp.receiveShadow = item.obj.receiveShadow
+				comp.$set({ scale: new Vector3().copy(item.obj.scale) })
+				comp.$set({ pos: new Vector3().copy(item.obj.position) })
+				comp.$set({ rot: new Euler().copy(item.obj.rotation) })
+				comp.$set({ castShadow: item.obj.castShadow })
+				comp.$set({ receiveShadow: item.obj.receiveShadow })
 			} else {
 				console.error(
 					`SVELTHREE > utils > SvelthreeGLTF > create_component : invalid 'item.svelthree_comp' (comp) value!`,

--- a/src/lib/utils/SvelthreeGLTF.ts
+++ b/src/lib/utils/SvelthreeGLTF.ts
@@ -10,7 +10,8 @@ import type {
 	SvelthreeGLTFTreeMap,
 	ISvelthreeGLTFTreeMapMember,
 	SvelthreeShadowDOMElement,
-	SvelthreeComponentShadowDOMChild
+	SvelthreeComponentShadowDOMChild,
+	MeshAssignableMaterial
 } from "../types/types-extra"
 
 export default class SvelthreeGLTF {
@@ -128,7 +129,7 @@ export default class SvelthreeGLTF {
 									target: dom_target,
 									props: {
 										geometry: item.mesh.geometry,
-										material: item.mesh.material,
+										material: item.mesh.material as MeshAssignableMaterial,
 										name: item.name
 									},
 									context

--- a/src/lib/utils/SvelthreeStoreArray.ts
+++ b/src/lib/utils/SvelthreeStoreArray.ts
@@ -28,7 +28,7 @@ class SvelthreeStoreArray_Base extends Array {
 			if (this.head_path?.length) {
 				// Don't use accessor if `this[i]` is a component (see `CubeCamera`)
 				if (Object.hasOwn(this[i], "$$")) {
-					const comp_state = this[i].$capture_state()
+					const comp_state = this[i].state()
 					prop_head = comp_state[this.head_path[0]]
 				} else {
 					prop_head = this[i][this.head_path[0]]

--- a/src/lib/utils/SvelthreeStoreArray.ts
+++ b/src/lib/utils/SvelthreeStoreArray.ts
@@ -26,7 +26,13 @@ class SvelthreeStoreArray_Base extends Array {
 			let prop_head: { [key: string]: unknown } | undefined
 
 			if (this.head_path?.length) {
-				prop_head = this[i][this.head_path[0]]
+				// Don't use accessor if `this[i]` is a component (see `CubeCamera`)
+				if (Object.hasOwn(this[i], "$$")) {
+					const comp_state = this[i].$capture_state()
+					prop_head = comp_state[this.head_path[0]]
+				} else {
+					prop_head = this[i][this.head_path[0]]
+				}
 
 				let j = 1
 				while (j < this.head_path.length) {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -24,6 +24,7 @@ const config = {
 		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 		exports: (filepath) => {
 			if (filepath.startsWith(`index.ts`)) return true
+			if (filepath.startsWith(`acc/index.ts`)) return true
 			if (filepath.startsWith(`utils/index`)) return true
 			if (filepath.startsWith(`stores/index`)) return true
 		}


### PR DESCRIPTION
Switching to `default-svelte-first` approach. (Closes #196)

For the sake of general `svelthree`-acceptance, faster development and last but not least: performance, [`svelte-accmod`](https://github.com/vatro/svelte-accmod)-first approach has been dropped for the upcoming `svelthree-1.0.0-next.1` release. `accessors` usage will not be recommended for various reasons which are yet to be nailed down in more detail (_basically the reasons why I created `svelte-accmod` in the first place_).

**Most important changes:**
- `svelthree`-package now contains **two component-versions**:
  - one without any `<svelte:options />` element (**_accessors disabled_**): **default** `import { Foo } from "svelthree"`
  - and one with `<svelte:options accessors />` element (**_accessors enabled_**): `import { Foo } from "svelthree/acc"` which will import **correctly / better typed** components.
- the code has been **refactored not to use accessors-syntax** and is now using `$set` and the new component-method `state()` (_see below_) instead.
- **new component method `state()`** has been introduced as an **alternative to accessor-getters**. It's available on initialization and is being used internally to access components' props (state) during initialization (before mounting). It's also the standard `svelthree`-method for getting component's props without using accessors, basically something like the `dev`-only method `.$capture_state()`, but with `.state()`:

  - the returned Object (_state_) contains **only exported props**
  - the returned Object (_state_) **is typed** (`interface IState*`)

   _Remark:_ the `IState*` interfaces are being automatically generated for generated components. `Canvas` and `WebGLRenderer` interfaces need to be updated manually (atm).

**Various changes:**
- Further optimized `Material` related types, also introducing new types `MeshMaterialWithColor` and `MeshMaterialWithEnvMap`.
- `CubeCamera` is now using the new `MeshMaterialWithEnvMap`
- More types are being exported and can now be imported via `import type { Foo } from "svelthree"`
- Few type- and comment-fixes
- Updated dependencies: 
  - "svelte": "^3.54.0" analog current `create-svelte` entry
    _though it could also be `^3.44.0`, but I'll stick to `create-svelte` since `svelthree`-starters will be based on it_
  - "three": "0.125.x - 0.147.x"
  - "@types/three": "0.125.x - 0.147.x" (_although currently no 0.147.x_)
  - the rest of `devDependencies` to latest versions
